### PR TITLE
feat: Slide Mode keyboard shortcuts, Favorites Mode, and source position indicator (#23)

### DIFF
--- a/Erimil/Erimil/ContentView.swift
+++ b/Erimil/Erimil/ContentView.swift
@@ -3,6 +3,7 @@
 //  Erimil
 //
 //  Created by Masahito Zembutsu on 2025/12/13.
+//  Updated: S010 (2025-01-11) - Sidebar double-click to open Slide Mode
 //
 
 import SwiftUI
@@ -19,6 +20,9 @@ struct ContentView: View {
     
     // S005: Flag to reopen Slide Mode after source switch
     @State private var shouldReopenSlideMode: Bool = false
+    
+    // S010: Flag to open Slide Mode from sidebar double-click
+    @State private var shouldOpenSlideMode: Bool = false
     
     // 確認ダイアログ用
     @State private var pendingSourceURL: URL?
@@ -40,6 +44,10 @@ struct ContentView: View {
                 onFolderSelectionAttempt: { url in
                     handleSourceSelectionAttempt(url: url, type: .folder)
                 },
+                onOpenSlideMode: { url in
+                    // S010: Open Slide Mode from sidebar double-click
+                    openSlideModeForSource(url)
+                },
                 reloadTrigger: folderReloadTrigger
             )
         } detail: {
@@ -59,6 +67,13 @@ struct ContentView: View {
                     shouldReopenSlideMode: $shouldReopenSlideMode
                 )
                 .id(imageSource.url)  // Force View recreation when source changes
+                // S010: Trigger Slide Mode open from sidebar
+                .onChange(of: shouldOpenSlideMode) { _, newValue in
+                    if newValue {
+                        shouldOpenSlideMode = false
+                        // ThumbnailGridView will handle opening Slide Mode via shouldReopenSlideMode
+                    }
+                }
             } else {
                 ContentUnavailableView(
                     "ZIPファイルまたはフォルダを選択",
@@ -178,6 +193,15 @@ struct ContentView: View {
     
     private func reloadFolder() {
         folderReloadTrigger = UUID()
+    }
+    
+    // MARK: - S010: Open Slide Mode from Sidebar
+    
+    private func openSlideModeForSource(_ url: URL) {
+        print("[ContentView] openSlideModeForSource: \(url.lastPathComponent)")
+        
+        // S010: Always set the flag - ThumbnailGridView will handle it via onChange
+        shouldReopenSlideMode = true
     }
     
     // MARK: - Source Navigation (S005)

--- a/Erimil/Erimil/SlideWindowController.swift
+++ b/Erimil/Erimil/SlideWindowController.swift
@@ -856,8 +856,10 @@ struct SlideWindowView: View {
                     .padding(.leading, 12)
                 }
                 
-                // Row 2: Image position indicator (within current source)
-                if entries.count > 1 {
+                //// Row 2: Image position indicator (within current source)
+                // if entries.count > 1 {
+                // Row 2: Image position indicator (always show for consistent layout)
+                if !entries.isEmpty {
                     ImagePositionBar(
                         current: currentIndex + 1,
                         total: entries.count,

--- a/Erimil/Erimil/ThumbnailGridView.swift
+++ b/Erimil/Erimil/ThumbnailGridView.swift
@@ -243,6 +243,15 @@ struct ThumbnailGridView: View {
                 )
             }
         }
+        // S010: Watch for Slide Mode open request from sidebar double-click
+        .onChange(of: shouldReopenSlideMode) { _, newValue in
+            if newValue && !entries.isEmpty && !SlideWindowController.shared.isOpen {
+                print("[ThumbnailGridView] shouldReopenSlideMode triggered, opening Slide Mode")
+                shouldReopenSlideMode = false
+                let index = focusedIndex ?? 0
+                previewMode = .slideMode(index: index)
+            }
+        }
         // Slide Mode - opens separate fullscreen window
         .onChange(of: previewMode) { oldMode, newMode in
             print("[ThumbnailGridView] previewMode changed: \(oldMode) → \(newMode)")

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A macOS application for visual preview and selective extraction of images from Z
 - **Folder Support**: Also works with regular image folders
 - **Keyboard-Driven**: Navigate and select with keyboard shortcuts
 - **Favorites System**: Mark important images with ★ for protection
+- **Slide Mode**: Fullscreen viewing with Favorites Mode for quick navigation
 
 ## Requirements
 
@@ -38,13 +39,64 @@ Toggle mode via the toolbar button or Settings.
 
 ### Keyboard Shortcuts
 
+#### Filer View (Thumbnail Grid)
+
 | Key | Action |
 |-----|--------|
 | ← → ↑ ↓ / WASD | Navigate thumbnails |
 | X | Toggle selection |
-| V | Toggle favorite ★ |
-| Space | Open preview |
-| Escape / Enter | Close preview |
+| F | Toggle favorite ★ |
+| Space | Open Quick Look preview |
+| Enter | Open Slide Mode (fullscreen) |
+| Ctrl+F | Open Slide Mode (alternative) |
+
+#### Quick Look Preview
+
+| Key | Action |
+|-----|--------|
+| ← → / A D | Navigate images |
+| Enter | Switch to Slide Mode |
+| Space / Esc | Close preview |
+
+#### Slide Mode (Fullscreen)
+
+| Key | Normal Mode | Favorites Mode |
+|-----|-------------|----------------|
+| ← → / A D | Previous/Next image | Previous/Next ★ |
+| Tab | Next ★ + **Enter Favorites Mode** | Next ★ |
+| F | Toggle favorite ★ | Toggle favorite ★ |
+| X | Toggle selection | Toggle selection |
+| Q | Exit fullscreen | Exit Favorites Mode |
+| Esc | Exit fullscreen | Exit fullscreen |
+| Ctrl+← / Ctrl+A | Previous source (ZIP/folder) | Previous source |
+| Ctrl+→ / Ctrl+D | Next source (ZIP/folder) | Next source |
+| Space | Toggle controls | Toggle controls |
+
+### Sidebar Navigation
+
+| Action | Result |
+|--------|--------|
+| Single-click | Select source, show thumbnails |
+| Double-click | Select source + open Slide Mode |
+
+### Slide Mode Features
+
+Slide Mode provides fullscreen image viewing with powerful navigation:
+
+**Position Indicators**
+- Image position bar: Shows current position with ★ (favorites) and × (selections) markers
+- Source position bar: Shows position among sibling ZIPs/folders in the same directory
+
+**Favorites Mode**
+- Press `Tab` to enter Favorites Mode and jump to the next favorite
+- `←/→` or `A/D` navigate between favorites only (skipping non-favorites)
+- Yellow header indicates Favorites Mode is active
+- Press `Q` to exit Favorites Mode (return to normal navigation)
+
+**Source Navigation**
+- `Ctrl+←/→` or `Ctrl+A/D` to switch between ZIPs/folders
+- Maintains fullscreen state during navigation
+- Loops from last to first (and vice versa)
 
 ## Favorites System
 
@@ -54,7 +106,7 @@ Erimil uses a **Hybrid Favorites** design that tracks favorites in two ways:
 
 Favorited in the current source (ZIP/folder). These are **protected** from deletion in Exclude mode.
 
-When you press `V` on an image:
+When you press `F` on an image:
 - The image is marked as ★ (direct favorite)
 - It cannot be selected for exclusion
 - Shows "PROTECTED" label in Exclude mode


### PR DESCRIPTION
## Summary
Enhanced Slide Mode with comprehensive keyboard shortcuts, a new Favorites Mode for quick navigation, and visual indicators for source/image position.

## Changes

### Keyboard Shortcuts
| Key | Action |
|-----|--------|
| f | Toggle favorite (unified) |
| x | Toggle selection |
| Enter | Open Slide Mode |
| Tab | Next ★ + Favorites Mode |
| q | Exit mode / fullscreen |
| Esc | Exit fullscreen |

### Favorites Mode
- Enter via Tab, exit via q
- a/d navigate favorites only
- Visual: yellow header + ★ badge

### UI
- Source position indicator (among sibling ZIPs/folders)
- Image position bar with ★/× markers
- Consistent layout (bar shown even for single image)

### Navigation
- Sidebar double-click → Slide Mode
- Ctrl+A/D source switching fix

## Testing
- [x] Keyboard shortcuts in filer
- [x] Keyboard shortcuts in Slide Mode
- [x] Favorites Mode enter/exit
- [x] Sidebar double-click
- [x] Ctrl+A/D source switching
- [x] Position indicators display