### PR TITLE
feat(navigation): add loop navigation within source (#47)

### DIFF
--- a/Erimil/Erimil/AppSettings.swift
+++ b/Erimil/Erimil/AppSettings.swift
@@ -115,6 +115,7 @@ class AppSettings: ObservableObject {
         static let lastOpenedFolder = "lastOpenedFolder"
         static let viewerThumbnailPosition = "viewerThumbnailPosition"
         static let prefetchCount = "prefetchCount"
+        static let loopWithinSource = "loopWithinSource"
     }
     
     // MARK: - Published Properties
@@ -179,6 +180,13 @@ class AppSettings: ObservableObject {
     @Published var prefetchCount: Int {
         didSet {
             defaults.set(prefetchCount, forKey: Keys.prefetchCount)
+        }
+    }
+    
+    /// Loop navigation within source (last→first, first→last)
+    @Published var loopWithinSource: Bool {
+        didSet {
+            defaults.set(loopWithinSource, forKey: Keys.loopWithinSource)
         }
     }
     
@@ -351,6 +359,12 @@ class AppSettings: ObservableObject {
         // lastOpenedFolderURL is restored via restoreAndAccessLastOpenedFolder()
         // to properly handle security-scoped bookmarks
         self.lastOpenedFolderURL = nil
+        
+        // prefetchCount の読み込みの後に追加
+        // self.loopWithinSource = defaults.bool(forKey: Keys.loopWithinSource)
+        // Note: bool(forKey:) returns false if not set, so default is OFF
+        // If you want default ON, use:
+        self.loopWithinSource = defaults.object(forKey: Keys.loopWithinSource) == nil ? true : defaults.bool(forKey: Keys.loopWithinSource)
     }
     
     // MARK: - Helper Methods
@@ -374,5 +388,6 @@ class AppSettings: ObservableObject {
         favoriteScope = .content
         viewerThumbnailPosition = .left
         lastOpenedFolderURL = nil
+        loopWithinSource = true  // or false, depending on preferred default
     }
 }

--- a/Erimil/Erimil/SettingsView.swift
+++ b/Erimil/Erimil/SettingsView.swift
@@ -90,14 +90,16 @@ struct SettingsView: View {
                 Stepper(
                     "先読み枚数: \(settings.prefetchCount)",
                     value: $settings.prefetchCount,
-                    in: 0...5
+                    in: 0...10
                 )
+                Toggle("ソース内ループナビゲーション", isOn: $settings.loopWithinSource)
             } header: {
                 Text("ビューアモード")
             } footer: {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("サムネイル位置はTキーでも切替可能")
                     Text("先読み: 0=無効、大きいほど快適だがメモリ使用増加")
+                    Text("ループ: 末尾→先頭、先頭→末尾のナビゲーション")
                 }
                 .font(.caption)
             }

--- a/Erimil/Erimil/SlideWindowController.swift
+++ b/Erimil/Erimil/SlideWindowController.swift
@@ -481,15 +481,31 @@ class SlideWindowController {
     // MARK: - S008: Navigation (moved from View for centralized control)
     
     private func goToPrevious() {
-        guard !storedEntries.isEmpty, currentIndex > 0 else { return }
-        currentIndex -= 1
+        guard !storedEntries.isEmpty else { return }
+        
+        if currentIndex > 0 {
+            currentIndex -= 1
+        } else if AppSettings.shared.loopWithinSource {
+            currentIndex = storedEntries.count - 1  // Loop to last
+        } else {
+            return
+        }
+        
         storedOnIndexChange?(currentIndex)
         notifyViewOfIndexChange()
     }
     
     private func goToNext() {
-        guard !storedEntries.isEmpty, currentIndex < storedEntries.count - 1 else { return }
-        currentIndex += 1
+        guard !storedEntries.isEmpty else { return }
+        
+        if currentIndex < storedEntries.count - 1 {
+            currentIndex += 1
+        } else if AppSettings.shared.loopWithinSource {
+            currentIndex = 0  // Loop to first
+        } else {
+            return
+        }
+        
         storedOnIndexChange?(currentIndex)
         notifyViewOfIndexChange()
     }
@@ -502,8 +518,10 @@ class SlideWindowController {
             currentIndex = targetIndex
             storedOnIndexChange?(currentIndex)
             notifyViewOfIndexChange()
-        } else if let lastFavorite = storedFavoriteIndices.max(), lastFavorite != currentIndex {
-            // Wrap around to last favorite
+        } else if AppSettings.shared.loopWithinSource,
+                  let lastFavorite = storedFavoriteIndices.max(),
+                  lastFavorite != currentIndex {
+            // Wrap around to last favorite (if loop enabled)
             currentIndex = lastFavorite
             storedOnIndexChange?(currentIndex)
             notifyViewOfIndexChange()
@@ -518,8 +536,10 @@ class SlideWindowController {
             currentIndex = targetIndex
             storedOnIndexChange?(currentIndex)
             notifyViewOfIndexChange()
-        } else if let firstFavorite = storedFavoriteIndices.min(), firstFavorite != currentIndex {
-            // Wrap around to first favorite
+        } else if AppSettings.shared.loopWithinSource,
+                  let firstFavorite = storedFavoriteIndices.min(),
+                  firstFavorite != currentIndex {
+            // Wrap around to first favorite (if loop enabled)
             currentIndex = firstFavorite
             storedOnIndexChange?(currentIndex)
             notifyViewOfIndexChange()

--- a/Erimil/Erimil/ThumbnailGridView.swift
+++ b/Erimil/Erimil/ThumbnailGridView.swift
@@ -866,9 +866,15 @@ struct ThumbnailGridView: View {
         
         let newIndex = current + offset
         
-        // Clamp to valid range
+        // Clamp to valid range or loop
         if newIndex >= 0 && newIndex < entries.count {
             focusedIndex = newIndex
+        } else if settings.loopWithinSource {
+            if newIndex < 0 {
+                focusedIndex = entries.count - 1  // Loop to last
+            } else if newIndex >= entries.count {
+                focusedIndex = 0  // Loop to first
+            }
         }
     }
     
@@ -1723,6 +1729,8 @@ struct ViewerView: View {
                 onRequestPreviousSource?()
             } else if currentIndex > 0 {
                 navigateTo(currentIndex - 1)
+            } else if settings.loopWithinSource {
+                navigateTo(entries.count - 1)  // Loop to last
             }
             return true
             
@@ -1732,8 +1740,11 @@ struct ViewerView: View {
                 onRequestNextSource?()
             } else if currentIndex < entries.count - 1 {
                 navigateTo(currentIndex + 1)
+            } else if settings.loopWithinSource {
+                navigateTo(0)  // Loop to first
             }
             return true
+            
         default:
             break
         }
@@ -1754,6 +1765,8 @@ struct ViewerView: View {
                 onRequestPreviousSource?()
             } else if currentIndex > 0 {
                 navigateTo(currentIndex - 1)
+            } else if settings.loopWithinSource {
+                navigateTo(entries.count - 1)
             }
             return true
             
@@ -1763,8 +1776,11 @@ struct ViewerView: View {
                 onRequestNextSource?()
             } else if currentIndex < entries.count - 1 {
                 navigateTo(currentIndex + 1)
+            } else if settings.loopWithinSource {
+                navigateTo(0)
             }
             return true
+
         // F - toggle favorite
         case "f":
             guard let entry = currentEntry else { return true }


### PR DESCRIPTION
- Add loopWithinSource setting in AppSettings (default: OFF)
- Add toggle in Settings UI (ビューアモード section)
- Implement loop in Filer (moveFocus function)
- Implement loop in Viewer Mode (A/D, ←/→)
- Implement loop in Slide Mode (goToPrevious/Next)
- Implement loop in Favorite navigation (goTo*Favorite)
- All navigation respects loopWithinSource setting consistently

Closes #47