### PR TITLE
feat: Add W/S/↑/↓ key bindings for unified navigation (#53)

### DIFF
--- a/Erimil/Erimil/SlideWindowController.swift
+++ b/Erimil/Erimil/SlideWindowController.swift
@@ -8,6 +8,7 @@
 //  Updated: S008 (2025-01-09) - Centralized key handling for empty source support (#21)
 //  Updated: S010 (2025-01-11) - Added source position indicator (#23)
 //  Updated: S010 (2025-01-11) - Added Favorites Mode, f/x toggles (#23 continued)
+//  Updated: S017 (2026-01-24) - Added W/S/↑/↓ key bindings (#53)
 //
 
 import SwiftUI
@@ -418,6 +419,36 @@ class SlideWindowController {
                 return nil
             }
         
+        // Up arrow (same as Left) - S017
+        case 126:
+            if hasControl {
+                print("[SlideWindowController] → Previous source (Ctrl+↑)")
+                storedOnPreviousSource?()
+                return nil
+            } else if isFavoritesMode {
+                print("[SlideWindowController] → Previous favorite (↑ in Favorites Mode)")
+                goToPreviousFavorite()
+                return nil
+            } else {
+                goToPrevious()
+                return nil
+            }
+            
+        // Down arrow (same as Right) - S017
+        case 125:
+            if hasControl {
+                print("[SlideWindowController] → Next source (Ctrl+↓)")
+                storedOnNextSource?()
+                return nil
+            } else if isFavoritesMode {
+                print("[SlideWindowController] → Next favorite (↓ in Favorites Mode)")
+                goToNextFavorite()
+                return nil
+            } else {
+                goToNext()
+                return nil
+            }
+        
         // R - exit to Viewer Mode (Reader)
         case 15:
             print("[SlideWindowController] → Exit to Viewer Mode (R)")
@@ -448,6 +479,32 @@ class SlideWindowController {
                         storedOnNextSource?()
                     } else if isFavoritesMode {
                         print("[SlideWindowController] → Next favorite (D in Favorites Mode)")
+                        goToNextFavorite()
+                    } else {
+                        goToNext()
+                    }
+                    return nil
+                
+                // S017: W key (same as A)
+                case "w":
+                    if hasControl {
+                        print("[SlideWindowController] → Previous source (Ctrl+W)")
+                        storedOnPreviousSource?()
+                    } else if isFavoritesMode {
+                        print("[SlideWindowController] → Previous favorite (W in Favorites Mode)")
+                        goToPreviousFavorite()
+                    } else {
+                        goToPrevious()
+                    }
+                    return nil
+                    
+                // S017: S key (same as D)
+                case "s":
+                    if hasControl {
+                        print("[SlideWindowController] → Next source (Ctrl+S)")
+                        storedOnNextSource?()
+                    } else if isFavoritesMode {
+                        print("[SlideWindowController] → Next favorite (S in Favorites Mode)")
                         goToNextFavorite()
                     } else {
                         goToNext()

--- a/Erimil/Erimil/ThumbnailGridView.swift
+++ b/Erimil/Erimil/ThumbnailGridView.swift
@@ -3,6 +3,7 @@
 //  Erimil
 //
 //  Created by Masahito Zembutsu on 2025/12/13.
+//  Updated: S017 (2026-01-24) - Added W/S/↑/↓ key bindings (#53)
 //
 
 import SwiftUI
@@ -804,16 +805,32 @@ struct ThumbnailGridView: View {
         switch event.keyCode {
         // Arrow keys
         case 123: // Left arrow
-            moveFocus(by: -1)
+            if event.modifierFlags.contains(.control) {
+                onRequestPreviousSource?()
+            } else {
+                moveFocus(by: -1)
+            }
             return true
         case 124: // Right arrow
-            moveFocus(by: 1)
+            if event.modifierFlags.contains(.control) {
+                onRequestNextSource?()
+            } else {
+                moveFocus(by: 1)
+            }
             return true
-        case 126: // Up arrow
-            moveFocus(by: -columnCount)
+        case 126: // Up arrow - S017: added Ctrl+ for source nav
+            if event.modifierFlags.contains(.control) {
+                onRequestPreviousSource?()
+            } else {
+                moveFocus(by: -columnCount)
+            }
             return true
-        case 125: // Down arrow
-            moveFocus(by: columnCount)
+        case 125: // Down arrow - S017: added Ctrl+ for source nav
+            if event.modifierFlags.contains(.control) {
+                onRequestNextSource?()
+            } else {
+                moveFocus(by: columnCount)
+            }
             return true
             
         // Escape
@@ -872,11 +889,21 @@ struct ThumbnailGridView: View {
                 moveFocus(by: 1)
             }
             return true
+        // S017: W - row up, Ctrl+W - previous source
         case "w":
-            moveFocus(by: -columnCount)
+            if event.modifierFlags.contains(.control) {
+                onRequestPreviousSource?()
+            } else {
+                moveFocus(by: -columnCount)
+            }
             return true
+        // S017: S - row down, Ctrl+S - next source
         case "s":
-            moveFocus(by: columnCount)
+            if event.modifierFlags.contains(.control) {
+                onRequestNextSource?()
+            } else {
+                moveFocus(by: columnCount)
+            }
             return true
             
         // X key - toggle selection
@@ -1815,6 +1842,28 @@ struct ViewerView: View {
                 navigateTo(0)  // Loop to first
             }
             return true
+        
+        // Up arrow (same as Left) - S017
+        case 126:
+            if event.modifierFlags.contains(.control) {
+                onRequestPreviousSource?()
+            } else if currentIndex > 0 {
+                navigateTo(currentIndex - 1)
+            } else if settings.loopWithinSource {
+                navigateTo(entries.count - 1)
+            }
+            return true
+            
+        // Down arrow (same as Right) - S017
+        case 125:
+            if event.modifierFlags.contains(.control) {
+                onRequestNextSource?()
+            } else if currentIndex < entries.count - 1 {
+                navigateTo(currentIndex + 1)
+            } else if settings.loopWithinSource {
+                navigateTo(0)
+            }
+            return true
 
         // F key (keyCode 3) - Ctrl+F = Slide Mode
         case 3:
@@ -1854,6 +1903,28 @@ struct ViewerView: View {
             
         // D - next (Ctrl+D = next source)
         case "d":
+            if event.modifierFlags.contains(.control) {
+                onRequestNextSource?()
+            } else if currentIndex < entries.count - 1 {
+                navigateTo(currentIndex + 1)
+            } else if settings.loopWithinSource {
+                navigateTo(0)
+            }
+            return true
+        
+        // S017: W - previous (Ctrl+W = previous source)
+        case "w":
+            if event.modifierFlags.contains(.control) {
+                onRequestPreviousSource?()
+            } else if currentIndex > 0 {
+                navigateTo(currentIndex - 1)
+            } else if settings.loopWithinSource {
+                navigateTo(entries.count - 1)
+            }
+            return true
+            
+        // S017: S - next (Ctrl+S = next source)
+        case "s":
             if event.modifierFlags.contains(.control) {
                 onRequestNextSource?()
             } else if currentIndex < entries.count - 1 {


### PR DESCRIPTION
- Slide Mode: W/S/↑/↓ work same as A/D/←/→
- Viewer Mode: Same key unification
- Filer (Grid): Ctrl+W/S/↑/↓ for source navigation
- Plain W/S/↑/↓ in Filer = row-based movement (unchanged)

Files modified:
- SlideWindowController.swift
- ThumbnailGridView.swift