### PR TITLE
fix(#73): Prevent double RTL inversion in spread view

### DIFF
--- a/Erimil/Erimil/SpreadImageViewer.swift
+++ b/Erimil/Erimil/SpreadImageViewer.swift
@@ -378,6 +378,7 @@ struct SpreadImageViewer: View {
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)  // Center in available space
+            .environment(\.layoutDirection, .leftToRight)  // #73: Prevent double RTL inversion
             .drawingGroup()  // Render offscreen first, then display at once
         }
     }


### PR DESCRIPTION
SpreadImageViewer's HStack was being affected by parent's layoutDirection environment, causing RTL to be applied twice (once by isRTL logic, once by environment) and canceling out.

Added explicit .leftToRight environment to the spread HStack so the component controls its own layout regardless of parent.