### PR TITLE
fix(#76): Invert navigation keys in RTL mode

### DIFF
--- a/Erimil/Erimil/ImagePreviewView.swift
+++ b/Erimil/Erimil/ImagePreviewView.swift
@@ -6,6 +6,7 @@
 //  Updated: S003 (2025-12-17) - Phase 2.2 Quick Look + navigation
 //  Updated: S020 (2026-01-26) - Spread (two-page) view support (#55)
 //  Updated: S021 (2026-01-26) - Refactoring: Use SpreadNavigationHelper (#67)
+//  Updated: S026 (2026-01-30) - RTL navigation key inversion (#76)
 //
 
 import SwiftUI
@@ -35,6 +36,11 @@ struct ImagePreviewView: View {
         AppSettings.shared.isSpreadModeEnabled
     }
     
+    // #76: Check if current source uses RTL direction
+    private var isRTL: Bool {
+        CacheManager.shared.getEffectiveReadingDirection(for: imageSource.url) == .rtl
+    }
+    
     var body: some View {
         ZStack {
             // #55/#67: Spread-aware image viewer (now from separate file)
@@ -53,12 +59,13 @@ struct ImagePreviewView: View {
             }
             
             // Key event handler (transparent to clicks)
+            // #76: RTL mode inverts navigation direction
             QuickLookKeyHandler(
                 onClose: onClose,
-                onPrevious: { goToPrevious() },
-                onNext: { goToNext() },
-                onPreviousFavorite: { goToPreviousFavorite() },
-                onNextFavorite: { goToNextFavorite() },
+                onPrevious: { isRTL ? goToNext() : goToPrevious() },
+                onNext: { isRTL ? goToPrevious() : goToNext() },
+                onPreviousFavorite: { isRTL ? goToNextFavorite() : goToPreviousFavorite() },
+                onNextFavorite: { isRTL ? goToPreviousFavorite() : goToNextFavorite() },
                 onToggleFullScreen: onToggleFullScreen,
                 onToggleSinglePage: { toggleSinglePageMarker() }  // #55
             )

--- a/Erimil/Erimil/SlideWindowController.swift
+++ b/Erimil/Erimil/SlideWindowController.swift
@@ -12,6 +12,7 @@
 //  Updated: S017 (2026-01-24) - Resume last viewed position (#52)
 //  Updated: S020 (2026-01-26) - Spread (two-page) view mode (#55)
 //  Updated: S021 (2026-01-26) - Refactoring: SpreadImageViewer extracted to separate file (#67)
+//  Updated: S026 (2026-01-30) - RTL navigation key inversion (#76)
 //
 
 import SwiftUI
@@ -55,6 +56,12 @@ class SlideWindowController {
     
     // S010: Favorites Mode state
     private var isFavoritesMode: Bool = false
+    
+    // #76: RTL navigation support
+    private var isRTL: Bool {
+        guard let source = storedImageSource else { return false }
+        return CacheManager.shared.getEffectiveReadingDirection(for: source.url) == .rtl
+    }
     
     private init() {}
     
@@ -412,11 +419,13 @@ class SlideWindowController {
                 storedOnPreviousSource?()
                 return nil
             } else if isFavoritesMode {
-                print("[SlideWindowController] → Previous favorite (← in Favorites Mode)")
-                goToPreviousFavorite()
+                // #76: RTL inverts direction
+                print("[SlideWindowController] → \(isRTL ? "Next" : "Previous") favorite (← in Favorites Mode)")
+                isRTL ? goToNextFavorite() : goToPreviousFavorite()
                 return nil
             } else {
-                goToPrevious()
+                // #76: RTL inverts direction
+                isRTL ? goToNext() : goToPrevious()
                 return nil
             }
             
@@ -427,11 +436,13 @@ class SlideWindowController {
                 storedOnNextSource?()
                 return nil
             } else if isFavoritesMode {
-                print("[SlideWindowController] → Next favorite (→ in Favorites Mode)")
-                goToNextFavorite()
+                // #76: RTL inverts direction
+                print("[SlideWindowController] → \(isRTL ? "Previous" : "Next") favorite (→ in Favorites Mode)")
+                isRTL ? goToPreviousFavorite() : goToNextFavorite()
                 return nil
             } else {
-                goToNext()
+                // #76: RTL inverts direction
+                isRTL ? goToPrevious() : goToNext()
                 return nil
             }
         
@@ -442,11 +453,13 @@ class SlideWindowController {
                 storedOnPreviousSource?()
                 return nil
             } else if isFavoritesMode {
-                print("[SlideWindowController] → Previous favorite (↑ in Favorites Mode)")
-                goToPreviousFavorite()
+                // #76: RTL inverts direction
+                print("[SlideWindowController] → \(isRTL ? "Next" : "Previous") favorite (↑ in Favorites Mode)")
+                isRTL ? goToNextFavorite() : goToPreviousFavorite()
                 return nil
             } else {
-                goToPrevious()
+                // #76: RTL inverts direction
+                isRTL ? goToNext() : goToPrevious()
                 return nil
             }
             
@@ -457,11 +470,13 @@ class SlideWindowController {
                 storedOnNextSource?()
                 return nil
             } else if isFavoritesMode {
-                print("[SlideWindowController] → Next favorite (↓ in Favorites Mode)")
-                goToNextFavorite()
+                // #76: RTL inverts direction
+                print("[SlideWindowController] → \(isRTL ? "Previous" : "Next") favorite (↓ in Favorites Mode)")
+                isRTL ? goToPreviousFavorite() : goToNextFavorite()
                 return nil
             } else {
-                goToNext()
+                // #76: RTL inverts direction
+                isRTL ? goToPrevious() : goToNext()
                 return nil
             }
         
@@ -493,10 +508,12 @@ class SlideWindowController {
                         print("[SlideWindowController] → Previous source (Ctrl+A)")
                         storedOnPreviousSource?()
                     } else if isFavoritesMode {
-                        print("[SlideWindowController] → Previous favorite (A in Favorites Mode)")
-                        goToPreviousFavorite()
+                        // #76: RTL inverts direction
+                        print("[SlideWindowController] → \(isRTL ? "Next" : "Previous") favorite (A in Favorites Mode)")
+                        isRTL ? goToNextFavorite() : goToPreviousFavorite()
                     } else {
-                        goToPrevious()
+                        // #76: RTL inverts direction
+                        isRTL ? goToNext() : goToPrevious()
                     }
                     return nil
                     
@@ -505,10 +522,12 @@ class SlideWindowController {
                         print("[SlideWindowController] → Next source (Ctrl+D)")
                         storedOnNextSource?()
                     } else if isFavoritesMode {
-                        print("[SlideWindowController] → Next favorite (D in Favorites Mode)")
-                        goToNextFavorite()
+                        // #76: RTL inverts direction
+                        print("[SlideWindowController] → \(isRTL ? "Previous" : "Next") favorite (D in Favorites Mode)")
+                        isRTL ? goToPreviousFavorite() : goToNextFavorite()
                     } else {
-                        goToNext()
+                        // #76: RTL inverts direction
+                        isRTL ? goToPrevious() : goToNext()
                     }
                     return nil
                 
@@ -518,10 +537,12 @@ class SlideWindowController {
                         print("[SlideWindowController] → Previous source (Ctrl+W)")
                         storedOnPreviousSource?()
                     } else if isFavoritesMode {
-                        print("[SlideWindowController] → Previous favorite (W in Favorites Mode)")
-                        goToPreviousFavorite()
+                        // #76: RTL inverts direction
+                        print("[SlideWindowController] → \(isRTL ? "Next" : "Previous") favorite (W in Favorites Mode)")
+                        isRTL ? goToNextFavorite() : goToPreviousFavorite()
                     } else {
-                        goToPrevious()
+                        // #76: RTL inverts direction
+                        isRTL ? goToNext() : goToPrevious()
                     }
                     return nil
                     
@@ -531,10 +552,12 @@ class SlideWindowController {
                         print("[SlideWindowController] → Next source (Ctrl+S)")
                         storedOnNextSource?()
                     } else if isFavoritesMode {
-                        print("[SlideWindowController] → Next favorite (S in Favorites Mode)")
-                        goToNextFavorite()
+                        // #76: RTL inverts direction
+                        print("[SlideWindowController] → \(isRTL ? "Previous" : "Next") favorite (S in Favorites Mode)")
+                        isRTL ? goToPreviousFavorite() : goToNextFavorite()
                     } else {
-                        goToNext()
+                        // #76: RTL inverts direction
+                        isRTL ? goToPrevious() : goToNext()
                     }
                     return nil
                     

--- a/Erimil/Erimil/ThumbnailGridView.swift
+++ b/Erimil/Erimil/ThumbnailGridView.swift
@@ -6,6 +6,7 @@
 //  Updated: S017 (2026-01-24) - Added W/S/↑/↓ key bindings (#53)
 //  Updated: S017 (2026-01-24) - Resume last viewed position (#52)
 //  Updated: S020 (2026-01-26) - V key for single page marker (#55)
+//  Updated: S026 (2026-01-30) - RTL navigation key inversion (#76)
 //
 
 import SwiftUI
@@ -1603,6 +1604,11 @@ struct ViewerView: View {
     private var effectiveReadingDirection: ReadingDirection {
         CacheManager.shared.getEffectiveReadingDirection(for: imageSource.url)
     }
+    
+    /// #76: Check if RTL mode for navigation key inversion
+    private var isRTL: Bool {
+        effectiveReadingDirection == .rtl
+    }
 
     private var currentEntry: ImageEntry? {
         guard viewerIndex >= 0, viewerIndex < entries.count else { return nil }
@@ -1983,7 +1989,8 @@ struct ViewerView: View {
             if event.modifierFlags.contains(.control) {
                 onRequestPreviousSource?()
             } else {
-                goToPrevious()
+                // #76: RTL inverts direction
+                isRTL ? goToNext() : goToPrevious()
             }
             return true
             
@@ -1992,11 +1999,13 @@ struct ViewerView: View {
             if event.modifierFlags.contains(.control) {
                 onRequestNextSource?()
             } else {
-                goToNext()
+                // #76: RTL inverts direction
+                isRTL ? goToPrevious() : goToNext()
             }
             return true
         
         // Up arrow (same as Left) - S017
+        // #76: Up/Down don't invert in ViewerMode (vertical thumbnail consistency)
         case 126:
             if event.modifierFlags.contains(.control) {
                 onRequestPreviousSource?()
@@ -2006,6 +2015,7 @@ struct ViewerView: View {
             return true
             
         // Down arrow (same as Right) - S017
+        // #76: Up/Down don't invert in ViewerMode (vertical thumbnail consistency)
         case 125:
             if event.modifierFlags.contains(.control) {
                 onRequestNextSource?()
@@ -2046,7 +2056,8 @@ struct ViewerView: View {
             if event.modifierFlags.contains(.control) {
                 onRequestPreviousSource?()
             } else {
-                goToPrevious()
+                // #76: RTL inverts direction
+                isRTL ? goToNext() : goToPrevious()
             }
             return true
             
@@ -2055,11 +2066,13 @@ struct ViewerView: View {
             if event.modifierFlags.contains(.control) {
                 onRequestNextSource?()
             } else {
-                goToNext()
+                // #76: RTL inverts direction
+                isRTL ? goToPrevious() : goToNext()
             }
             return true
         
         // S017: W - previous (Ctrl+W = previous source)
+        // #76: W/S don't invert in ViewerMode (same as Up/Down)
         case "w":
             if event.modifierFlags.contains(.control) {
                 onRequestPreviousSource?()
@@ -2069,6 +2082,7 @@ struct ViewerView: View {
             return true
             
         // S017: S - next (Ctrl+S = next source)
+        // #76: W/S don't invert in ViewerMode (same as Up/Down)
         case "s":
             if event.modifierFlags.contains(.control) {
                 onRequestNextSource?()


### PR DESCRIPTION
RTL reading direction now inverts ←→AD keys for page navigation.

Changes:
- SlideWindowController: All navigation keys invert (←→↑↓ADWS)
- ImagePreviewView (QuickLook): ←→AD invert via callbacks
- ThumbnailGridView (ViewerMode): ←→AD invert, ↑↓WS unchanged (vertical thumbnail consistency)

Design decisions:
- Ctrl+arrows (source navigation) remain physical direction
- FavoritesMode follows same inversion rules
- ViewerMode keeps ↑=prev, ↓=next for vertical sidebar alignment

Closes #76