### PR TITLE
fix: Horizontal thumbnail bar no longer overlaps with file list sideb…

### DIFF
--- a/Erimil/Erimil/ThumbnailGridView.swift
+++ b/Erimil/Erimil/ThumbnailGridView.swift
@@ -1938,6 +1938,7 @@ struct ViewerView: View {
             }
             .allowsHitTesting(false)
         }
+        .clipped()
         .onAppear {
             if currentSourceURL != imageSource.url {
                 currentSourceURL = imageSource.url


### PR DESCRIPTION
…ar (#79)

Add .clipped() to ViewerView to constrain rendering within detail pane bounds. NavigationSplitView's detail area was allowing child views to render beyond its logical boundaries, causing the horizontal ThumbnailSidebarView to appear behind the file list sidebar.