### PR TITLE
fix: remove .public privacy from path/URL/name Logger interpolations …

### DIFF
--- a/Erimil/Erimil/AppSettings.swift
+++ b/Erimil/Erimil/AppSettings.swift
@@ -284,8 +284,8 @@ class AppSettings: ObservableObject {
     
     /// Save URL as security-scoped bookmark to file
     private func saveSecurityScopedBookmark(for url: URL) {
-        Logger.appSettings.debug("saveSecurityScopedBookmark called for: \(url.path, privacy: .public)")
-        Logger.appSettings.debug("Saving to file: \(self.bookmarkFileURL.path, privacy: .public)")
+        Logger.appSettings.debug("saveSecurityScopedBookmark called for: \(url.path)")
+        Logger.appSettings.debug("Saving to file: \(self.bookmarkFileURL.path)")
         
         do {
             let bookmarkData = try url.bookmarkData(
@@ -302,7 +302,7 @@ class AppSettings: ObservableObject {
             let verifyExists = FileManager.default.fileExists(atPath: bookmarkFileURL.path)
             Logger.appSettings.debug("Verify after save - file exists: \(verifyExists, privacy: .public)")
             
-            Logger.appSettings.info("Saved security-scoped bookmark for: \(url.path, privacy: .public)")
+            Logger.appSettings.info("Saved security-scoped bookmark for: \(url.path)")
         } catch {
             Logger.appSettings.error("Failed to save bookmark: \(error, privacy: .public)")
         }
@@ -311,7 +311,7 @@ class AppSettings: ObservableObject {
     /// Restore URL from security-scoped bookmark file and start accessing
     func restoreAndAccessLastOpenedFolder() -> URL? {
         Logger.appSettings.info("Attempting to restore last opened folder...")
-        Logger.appSettings.debug("Looking for file: \(self.bookmarkFileURL.path, privacy: .public)")
+        Logger.appSettings.debug("Looking for file: \(self.bookmarkFileURL.path)")
         
         // Check if file exists
         let fileExists = FileManager.default.fileExists(atPath: bookmarkFileURL.path)
@@ -334,7 +334,7 @@ class AppSettings: ObservableObject {
                 bookmarkDataIsStale: &isStale
             )
             
-            Logger.appSettings.info("Resolved bookmark to: \(url.path, privacy: .public), isStale: \(isStale, privacy: .public)")
+            Logger.appSettings.info("Resolved bookmark to: \(url.path), isStale: \(isStale, privacy: .public)")
             
             if isStale {
                 Logger.appSettings.debug("Bookmark is stale, will re-save")
@@ -343,7 +343,7 @@ class AppSettings: ObservableObject {
             
             // Start accessing the security-scoped resource
             if url.startAccessingSecurityScopedResource() {
-                Logger.appSettings.info("Started accessing security-scoped resource: \(url.path, privacy: .public)")
+                Logger.appSettings.info("Started accessing security-scoped resource: \(url.path)")
                 securityScopedURL = url
                 isAccessingSecurityScopedResource = true
                 return url

--- a/Erimil/Erimil/ArchiveManager.swift
+++ b/Erimil/Erimil/ArchiveManager.swift
@@ -70,10 +70,10 @@ class ArchiveManager: ImageSource {
     /// List all image entries in the ZIP
     func listImageEntries() -> [ImageEntry] {
         return accessQueue.sync {
-            Logger.archive.debug("listImageEntries called for: \(self.url.lastPathComponent, privacy: .public)")
+            Logger.archive.debug("listImageEntries called for: \(self.url.lastPathComponent)")
             
             guard let archive = openArchive() else {
-                Logger.archive.error("Failed to open archive: \(self.url, privacy: .public)")
+                Logger.archive.error("Failed to open archive: \(self.url)")
                 return []
             }
             
@@ -101,7 +101,7 @@ class ArchiveManager: ImageSource {
             Logger.archive.debug("Archive contains \(allEntries.count, privacy: .public) total entries")
             Logger.archive.debug("Found \(results.count, privacy: .public) image entries:")
             for (index, entry) in results.prefix(10).enumerated() {
-                Logger.archive.debug("  [\(index, privacy: .public)] \(entry.name, privacy: .public) - \(entry.path, privacy: .public)")
+                Logger.archive.debug("  [\(index, privacy: .public)] \(entry.name) - \(entry.path)")
             }
             if results.count > 10 {
                 Logger.archive.debug("  ... and \(results.count - 10, privacy: .public) more")
@@ -123,13 +123,13 @@ class ArchiveManager: ImageSource {
         if let contentHash = cache.getContentHash(for: pathHash) {
             // Try to get cached thumbnail
             if let cached = cache.getThumbnail(for: contentHash) {
-                Logger.thumbnailGrid.debug("Cache HIT for \(entry.name, privacy: .public)")
+                Logger.thumbnailGrid.debug("Cache HIT for \(entry.name)")
                 return cached
             }
         }
         
         // Cache miss - extract and generate
-        Logger.thumbnailGrid.debug("Cache MISS for \(entry.name, privacy: .public), extracting...")
+        Logger.thumbnailGrid.debug("Cache MISS for \(entry.name), extracting...")
         guard let (image, imageData) = extractImageWithData(for: entry) else { return nil }
         
         // Calculate content hash
@@ -157,10 +157,10 @@ class ArchiveManager: ImageSource {
     /// Extract image and raw data from ZIP
     private func extractImageWithData(for imageEntry: ImageEntry) -> (NSImage, Data)? {
         return accessQueue.sync {
-            Logger.archive.debug("Looking for '\(imageEntry.path, privacy: .public)' in '\(self.url.lastPathComponent, privacy: .public)'")
+            Logger.archive.debug("Looking for '\(imageEntry.path)' in '\(self.url.lastPathComponent)'")
             
             guard let archive = openArchive() else {
-                Logger.archive.error("Failed to open archive: \(self.url.path, privacy: .public)")
+                Logger.archive.error("Failed to open archive: \(self.url.path)")
                 return nil
             }
             
@@ -179,10 +179,10 @@ class ArchiveManager: ImageSource {
             }
             
             guard let entry = foundEntry else {
-                Logger.archive.debug("Entry not found: \(imageEntry.path, privacy: .public)")
-                Logger.archive.debug("ZIP '\(self.url.lastPathComponent, privacy: .public)' contains \(availablePaths.count, privacy: .public) entries:")
+                Logger.archive.debug("Entry not found: \(imageEntry.path)")
+                Logger.archive.debug("ZIP '\(self.url.lastPathComponent)' contains \(availablePaths.count, privacy: .public) entries:")
                 for path in availablePaths.prefix(10) {
-                    Logger.archive.debug("  - \(path, privacy: .public)")
+                    Logger.archive.debug("  - \(path)")
                 }
                 if availablePaths.count > 10 {
                     Logger.archive.debug("  ... and \(availablePaths.count - 10, privacy: .public) more")
@@ -196,12 +196,12 @@ class ArchiveManager: ImageSource {
                     imageData.append(data)
                 }
             } catch {
-                Logger.archive.error("Extract failed for \(imageEntry.name, privacy: .public): \(error, privacy: .public)")
+                Logger.archive.error("Extract failed for \(imageEntry.name): \(error, privacy: .public)")
                 return nil
             }
             
             guard let image = NSImage(data: imageData) else {
-                Logger.archive.error("Invalid image data for: \(imageEntry.name, privacy: .public), size: \(imageData.count, privacy: .public) bytes")
+                Logger.archive.error("Invalid image data for: \(imageEntry.name), size: \(imageData.count, privacy: .public) bytes")
                 return nil
             }
             
@@ -240,7 +240,7 @@ class ArchiveManager: ImageSource {
     /// Reference: https://github.com/weichsel/ZIPFoundation#adding-and-removing-entries
     func exportOptimized(excluding excludedPaths: Set<String>, to destinationURL: URL) throws {
         Logger.archive.info("exportOptimized called")
-        Logger.archive.debug("Excluded paths: \(excludedPaths, privacy: .public)")
+        Logger.archive.debug("Excluded paths: \(excludedPaths)")
         
         guard let sourceArchive = openArchive() else {
             Logger.archive.error("Failed to open source archive")
@@ -249,7 +249,7 @@ class ArchiveManager: ImageSource {
         Logger.archive.debug("Source archive opened")
         
         guard let destinationArchive = try? Archive(url: destinationURL, accessMode: .create) else {
-            Logger.archive.error("Failed to create destination archive at: \(destinationURL.path, privacy: .public)")
+            Logger.archive.error("Failed to create destination archive at: \(destinationURL.path)")
             throw ArchiveError.cannotCreateDestination
         }
         Logger.archive.debug("Destination archive created")
@@ -260,21 +260,21 @@ class ArchiveManager: ImageSource {
             let path = encoding != nil ? entry.path(using: encoding!) : entry.path
             
             if excludedPaths.contains(path) {
-                Logger.archive.debug("Excluding: \(path, privacy: .public)")
+                Logger.archive.debug("Excluding: \(path)")
                 continue
             }
             
             if path.contains("__MACOSX/") {
-                Logger.archive.debug("Skipping __MACOSX: \(path, privacy: .public)")
+                Logger.archive.debug("Skipping __MACOSX: \(path)")
                 continue
             }
             
             if entry.type == .directory {
-                Logger.archive.debug("Skipping directory: \(path, privacy: .public)")
+                Logger.archive.debug("Skipping directory: \(path)")
                 continue
             }
             
-            Logger.archive.debug("Copying: \(path, privacy: .public)")
+            Logger.archive.debug("Copying: \(path)")
             
             var entryData = Data()
             do {

--- a/Erimil/Erimil/CacheManager.swift
+++ b/Erimil/Erimil/CacheManager.swift
@@ -138,12 +138,12 @@ class CacheManager {
         do {
             if !fm.fileExists(atPath: baseDirectory.path) {
                 try fm.createDirectory(at: baseDirectory, withIntermediateDirectories: true)
-                Logger.cache.info("Created base directory: \(self.baseDirectory.path, privacy: .public)")
+                Logger.cache.info("Created base directory: \(self.baseDirectory.path)")
             }
             
             if !fm.fileExists(atPath: cacheDirectory.path) {
                 try fm.createDirectory(at: cacheDirectory, withIntermediateDirectories: true)
-                Logger.cache.info("Created cache directory: \(self.cacheDirectory.path, privacy: .public)")
+                Logger.cache.info("Created cache directory: \(self.cacheDirectory.path)")
             }
         } catch {
             Logger.cache.error("Failed to create directories: \(error, privacy: .public)")
@@ -801,7 +801,7 @@ class CacheManager {
         updateSourceSettings(for: sourceURL) { settings in
             settings.readingDirection = direction
         }
-        Logger.cache.debug("Set reading direction for \(sourceURL.lastPathComponent, privacy: .public): \(direction?.displayName ?? "global default")")
+        Logger.cache.debug("Set reading direction for \(sourceURL.lastPathComponent): \(direction?.displayName ?? "global default")")
     }
     
     /// Toggle reading direction for a source
@@ -986,7 +986,7 @@ class CacheManager {
         bookmarksLock.unlock()
         
         saveBookmarks()
-        Logger.cache.debug("Added bookmark '\(name, privacy: .public)' at index \(imageIndex, privacy: .public)")
+        Logger.cache.debug("Added bookmark '\(name)' at index \(imageIndex, privacy: .public)")
         return bookmark
     }
     
@@ -1036,7 +1036,7 @@ class CacheManager {
         bookmarksLock.unlock()
         
         saveBookmarks()
-        Logger.cache.debug("Updated bookmark name to '\(name, privacy: .public)'")
+        Logger.cache.debug("Updated bookmark name to '\(name)'")
     }
     
     /// Get sorted bookmark indices for a source (for navigation)

--- a/Erimil/Erimil/ContentView.swift
+++ b/Erimil/Erimil/ContentView.swift
@@ -125,7 +125,7 @@ struct ContentView: View {
         
         // Use security-scoped bookmark restoration
         if let restoredFolder = AppSettings.shared.restoreAndAccessLastOpenedFolder() {
-            Logger.content.info("Restored folder with security scope: \(restoredFolder.path, privacy: .public)")
+            Logger.content.info("Restored folder with security scope: \(restoredFolder.path)")
             selectedFolderURL = restoredFolder
             // Update the published property (without triggering didSet bookmark save)
             AppSettings.shared.lastOpenedFolderURL = restoredFolder
@@ -193,7 +193,7 @@ struct ContentView: View {
     // MARK: - S010: Open Slide Mode from Sidebar
     
     private func openSlideModeForSource(_ url: URL) {
-        Logger.content.debug("openSlideModeForSource: \(url.lastPathComponent, privacy: .public)")
+        Logger.content.debug("openSlideModeForSource: \(url.lastPathComponent)")
         
         // S010: Always set the flag - ThumbnailGridView will handle it via onChange
         shouldReopenSlideMode = true
@@ -208,7 +208,7 @@ struct ContentView: View {
         }
         
         if let nextURL = SourceNavigator.nextSource(from: currentURL) {
-            Logger.content.debug("navigateToNextSource: \(currentURL.lastPathComponent, privacy: .public) → \(nextURL.lastPathComponent, privacy: .public)")
+            Logger.content.debug("navigateToNextSource: \(currentURL.lastPathComponent) → \(nextURL.lastPathComponent)")
             let type = inferSourceType(nextURL)
             
             // S005: Set flag to reopen mode after source switch
@@ -232,7 +232,7 @@ struct ContentView: View {
         }
         
         if let prevURL = SourceNavigator.previousSource(from: currentURL) {
-            Logger.content.debug("navigateToPreviousSource: \(currentURL.lastPathComponent, privacy: .public) → \(prevURL.lastPathComponent, privacy: .public)")
+            Logger.content.debug("navigateToPreviousSource: \(currentURL.lastPathComponent) → \(prevURL.lastPathComponent)")
             let type = inferSourceType(prevURL)
             
             // S005: Set flag to reopen mode after source switch

--- a/Erimil/Erimil/FolderManager.swift
+++ b/Erimil/Erimil/FolderManager.swift
@@ -27,7 +27,7 @@ class FolderManager: ImageSource {
             includingPropertiesForKeys: [.fileSizeKey, .isRegularFileKey],
             options: [.skipsHiddenFiles]
         ) else {
-            Logger.folder.error("Failed to read folder: \(self.url, privacy: .public)")
+            Logger.folder.error("Failed to read folder: \(self.url)")
             return []
         }
         
@@ -65,22 +65,22 @@ class FolderManager: ImageSource {
         if let contentHash = cache.getContentHash(for: pathHash) {
             // Try to get cached thumbnail
             if let cached = cache.getThumbnail(for: contentHash) {
-                Logger.folder.debug("Cache HIT for \(entry.name, privacy: .public)")
+                Logger.folder.debug("Cache HIT for \(entry.name)")
                 return cached
             }
         }
         
         // Cache miss - load file and generate
-        Logger.folder.debug("Cache MISS for \(entry.name, privacy: .public), loading...")
+        Logger.folder.debug("Cache MISS for \(entry.name), loading...")
         let fileURL = URL(fileURLWithPath: entry.path)
         
         guard let imageData = try? Data(contentsOf: fileURL) else {
-            Logger.folder.error("Failed to read file: \(entry.path, privacy: .public)")
+            Logger.folder.error("Failed to read file: \(entry.path)")
             return nil
         }
         
         guard let image = NSImage(data: imageData) else {
-            Logger.folder.error("Invalid image data: \(entry.path, privacy: .public)")
+            Logger.folder.error("Invalid image data: \(entry.path)")
             return nil
         }
         
@@ -102,10 +102,10 @@ class FolderManager: ImageSource {
     /// Get full-size image - direct file access
     func fullImage(for entry: ImageEntry) -> NSImage? {
         let fileURL = URL(fileURLWithPath: entry.path)
-        Logger.folder.debug("Loading image: \(fileURL.lastPathComponent, privacy: .public)")
+        Logger.folder.debug("Loading image: \(fileURL.lastPathComponent)")
         
         guard let image = NSImage(contentsOf: fileURL) else {
-            Logger.folder.error("Failed to load: \(entry.path, privacy: .public)")
+            Logger.folder.error("Failed to load: \(entry.path)")
             return nil
         }
         return image
@@ -141,7 +141,7 @@ class FolderManager: ImageSource {
     /// Create ZIP from selected images (excluding excludedPaths)
     func createZip(excluding excludedPaths: Set<String>, to destinationURL: URL) throws {
         Logger.folder.info("createZip called")
-        Logger.folder.debug("Excluded paths: \(excludedPaths, privacy: .public)")
+        Logger.folder.debug("Excluded paths: \(excludedPaths)")
         
         guard let archive = Archive(url: destinationURL, accessMode: .create) else {
             throw FolderError.cannotCreateZip
@@ -151,7 +151,7 @@ class FolderManager: ImageSource {
         
         for entry in entries {
             if excludedPaths.contains(entry.path) {
-                Logger.folder.debug("Excluding: \(entry.name, privacy: .public)")
+                Logger.folder.debug("Excluding: \(entry.name)")
                 continue
             }
             
@@ -159,9 +159,9 @@ class FolderManager: ImageSource {
             
             do {
                 try archive.addEntry(with: entry.name, relativeTo: fileURL.deletingLastPathComponent())
-                Logger.folder.debug("Added: \(entry.name, privacy: .public)")
+                Logger.folder.debug("Added: \(entry.name)")
             } catch {
-                Logger.folder.error("Failed to add \(entry.name, privacy: .public): \(error, privacy: .public)")
+                Logger.folder.error("Failed to add \(entry.name): \(error, privacy: .public)")
             }
         }
         
@@ -177,10 +177,10 @@ class FolderManager: ImageSource {
             
             do {
                 try FileManager.default.trashItem(at: fileURL, resultingItemURL: nil)
-                Logger.folder.info("Trashed: \(fileURL.lastPathComponent, privacy: .public)")
+                Logger.folder.info("Trashed: \(fileURL.lastPathComponent)")
                 trashedCount += 1
             } catch {
-                Logger.folder.error("Failed to trash \(fileURL.lastPathComponent, privacy: .public): \(error, privacy: .public)")
+                Logger.folder.error("Failed to trash \(fileURL.lastPathComponent): \(error, privacy: .public)")
             }
         }
         

--- a/Erimil/Erimil/ImagePrefetcher.swift
+++ b/Erimil/Erimil/ImagePrefetcher.swift
@@ -153,7 +153,7 @@ class ImagePrefetcher {
                 // Load image
                 if let image = imageSource.fullImage(for: entry) {
                     self.addToCache(path: entry.path, image: image)
-                    Logger.prefetcher.debug("Prefetched: \(entry.name, privacy: .public) (index \(targetIndex, privacy: .public))")
+                    Logger.prefetcher.debug("Prefetched: \(entry.name) (index \(targetIndex, privacy: .public))")
                 }
             }
         }
@@ -217,7 +217,7 @@ class ImagePrefetcher {
         while cache.count > maxCacheSize && !accessOrder.isEmpty {
             let oldestPath = accessOrder.removeFirst()
             cache.removeValue(forKey: oldestPath)
-            Logger.prefetcher.debug("Evicted: \(oldestPath, privacy: .public)")
+            Logger.prefetcher.debug("Evicted: \(oldestPath)")
         }
     }
 }

--- a/Erimil/Erimil/ImageViewerCore.swift
+++ b/Erimil/Erimil/ImageViewerCore.swift
@@ -113,14 +113,14 @@ struct ImageViewerCore: View {
                 imageSource: imageSource,
                 previousIndex: previousIndex
             )
-            Logger.viewer.debug("Cache HIT for \(entry.name, privacy: .public)")
+            Logger.viewer.debug("Cache HIT for \(entry.name)")
             return
         }
         
         // Cache miss - load normally
         isLoading = true
         loadedImage = nil
-        Logger.viewer.debug("Cache MISS for \(entry.name, privacy: .public), loading...")
+        Logger.viewer.debug("Cache MISS for \(entry.name), loading...")
         
         // Capture for async
         let capturedSource = imageSource

--- a/Erimil/Erimil/KeyHandling.swift
+++ b/Erimil/Erimil/KeyHandling.swift
@@ -552,7 +552,7 @@ struct BookmarkDialogHelper {
             showDeleteDialog(bookmarkName: existing.name, window: window) { confirmed in
                 if confirmed {
                     CacheManager.shared.removeBookmark(for: sourceURL, id: existing.id)
-                    Logger.bookmark.debug("Deleted '\(existing.name, privacy: .public)' at index \(imageIndex, privacy: .public)")
+                    Logger.bookmark.debug("Deleted '\(existing.name)' at index \(imageIndex, privacy: .public)")
                     onChanged?()
                 }
             }
@@ -561,7 +561,7 @@ struct BookmarkDialogHelper {
             showAddDialog(defaultName: defaultName, window: window) { name in
                 if let name = name {
                     CacheManager.shared.addBookmark(for: sourceURL, at: imageIndex, name: name)
-                    Logger.bookmark.debug("Added '\(name, privacy: .public)' at index \(imageIndex, privacy: .public)")
+                    Logger.bookmark.debug("Added '\(name)' at index \(imageIndex, privacy: .public)")
                     onChanged?()
                 }
             }

--- a/Erimil/Erimil/PDFManager.swift
+++ b/Erimil/Erimil/PDFManager.swift
@@ -35,10 +35,10 @@ class PDFManager: ImageSource {
     /// List all pages as image entries
     func listImageEntries() -> [ImageEntry] {
         return accessQueue.sync {
-            Logger.pdf.debug("listImageEntries called for: \(self.url.lastPathComponent, privacy: .public)")
+            Logger.pdf.debug("listImageEntries called for: \(self.url.lastPathComponent)")
             
             guard let doc = openDocument() else {
-                Logger.pdf.error("Failed to open PDF: \(self.url, privacy: .public)")
+                Logger.pdf.error("Failed to open PDF: \(self.url)")
                 return []
             }
             
@@ -83,17 +83,17 @@ class PDFManager: ImageSource {
         // Check if we have cached thumbnail
         if let contentHash = cache.getContentHash(for: pathHash),
            let cached = cache.getThumbnail(for: contentHash) {
-            Logger.pdf.debug("Cache HIT for \(entry.name, privacy: .public)")
+            Logger.pdf.debug("Cache HIT for \(entry.name)")
             return cached
         }
         
         // Cache miss - render thumbnail
-        Logger.pdf.debug("Cache MISS for \(entry.name, privacy: .public), rendering...")
+        Logger.pdf.debug("Cache MISS for \(entry.name), rendering...")
         
         guard let pageIndex = pageIndex(from: entry.path),
               let doc = openDocument(),
               let page = doc.page(at: pageIndex) else {
-            Logger.pdf.error("Failed to get page for \(entry.path, privacy: .public)")
+            Logger.pdf.error("Failed to get page for \(entry.path)")
             return nil
         }
         
@@ -115,7 +115,7 @@ class PDFManager: ImageSource {
         cache.registerMapping(pathHash: pathHash, contentHash: contentHash)
         cache.saveThumbnail(thumbnail, for: contentHash)
         
-        Logger.pdf.debug("Generated and cached thumbnail for \(entry.name, privacy: .public)")
+        Logger.pdf.debug("Generated and cached thumbnail for \(entry.name)")
         return thumbnail
     }
     
@@ -125,7 +125,7 @@ class PDFManager: ImageSource {
             guard let pageIndex = pageIndex(from: entry.path),
                   let doc = openDocument(),
                   let page = doc.page(at: pageIndex) else {
-                Logger.pdf.error("fullImage: Failed to get page for \(entry.path, privacy: .public)")
+                Logger.pdf.error("fullImage: Failed to get page for \(entry.path)")
                 return nil
             }
             
@@ -156,7 +156,7 @@ class PDFManager: ImageSource {
             
             image.unlockFocus()
             
-            Logger.pdf.debug("Rendered full image for \(entry.name, privacy: .public): \(renderSize.debugDescription, privacy: .public)")
+            Logger.pdf.debug("Rendered full image for \(entry.name): \(renderSize.debugDescription, privacy: .public)")
             return image
         }
     }
@@ -168,7 +168,7 @@ class PDFManager: ImageSource {
         if document == nil {
             document = PDFDocument(url: url)
             if document == nil {
-                Logger.pdf.error("Failed to create PDFDocument for: \(self.url.path, privacy: .public)")
+                Logger.pdf.error("Failed to create PDFDocument for: \(self.url.path)")
             }
         }
         return document
@@ -181,7 +181,7 @@ class PDFManager: ImageSource {
         guard path.hasPrefix("page_"),
               let numberString = path.split(separator: "_").last,
               let pageNumber = Int(numberString) else {
-            Logger.pdf.error("Invalid path format: \(path, privacy: .public)")
+            Logger.pdf.error("Invalid path format: \(path)")
             return nil
         }
         

--- a/Erimil/Erimil/SidebarView.swift
+++ b/Erimil/Erimil/SidebarView.swift
@@ -125,7 +125,7 @@ struct SidebarView: View {
                 rootNode = FolderNode(url: url)
                 Logger.sidebar.info("rootNode created, children count: \(rootNode?.children?.count ?? 0, privacy: .public)")
             } else {
-                Logger.sidebar.error("ERROR: Folder does not exist: \(url.path, privacy: .public)")
+                Logger.sidebar.error("ERROR: Folder does not exist: \(url.path)")
                 // Fallback to Desktop
                 fallbackToDesktop()
             }
@@ -157,7 +157,7 @@ struct SidebarView: View {
         Logger.sidebar.debug("Folder picker response: \(response == .OK ? "OK" : "Cancel")")
         
         if response == .OK, let url = panel.url {
-            Logger.sidebar.debug("Selected folder: \(url.path, privacy: .public)")
+            Logger.sidebar.debug("Selected folder: \(url.path)")
             
             // Force update even if same folder (by clearing first)
             if selectedFolderURL == url {

--- a/Erimil/Erimil/SlideWindowController.swift
+++ b/Erimil/Erimil/SlideWindowController.swift
@@ -91,7 +91,7 @@ class SlideWindowController {
     ) {
         Logger.slideWindow.debug("open() called")
         Logger.slideWindow.debug("entries.count: \(entries.count, privacy: .public), initialIndex: \(initialIndex, privacy: .public), favorites: \(favoriteIndices.count, privacy: .public)")
-        Logger.slideWindow.debug("source: \(sourceName, privacy: .public) (\(sourcePosition, privacy: .public)/\(totalSources, privacy: .public))")
+        Logger.slideWindow.debug("source: \(sourceName) (\(sourcePosition, privacy: .public)/\(totalSources, privacy: .public))")
         
         // Close existing window if any
         close()
@@ -286,7 +286,7 @@ class SlideWindowController {
         
         Logger.slideWindow.debug("updateSource: updating content in-place")
         Logger.slideWindow.debug("new entries.count: \(entries.count, privacy: .public), favorites: \(favoriteIndices.count, privacy: .public)")
-        Logger.slideWindow.debug("source: \(sourceName, privacy: .public) (\(sourcePosition, privacy: .public)/\(totalSources, privacy: .public))")
+        Logger.slideWindow.debug("source: \(sourceName) (\(sourcePosition, privacy: .public)/\(totalSources, privacy: .public))")
         
         // #52: Restore last position for new source
         let startIndex: Int

--- a/Erimil/Erimil/SourceNavigator.swift
+++ b/Erimil/Erimil/SourceNavigator.swift
@@ -69,7 +69,7 @@ struct SourceNavigator {
             includingPropertiesForKeys: [.isDirectoryKey],
             options: [.skipsHiddenFiles]
         ) else {
-            Logger.sourceNav.error("Failed to list contents of \(parentURL.path, privacy: .public)")
+            Logger.sourceNav.error("Failed to list contents of \(parentURL.path)")
             return []
         }
         
@@ -86,7 +86,7 @@ struct SourceNavigator {
             $0.lastPathComponent.localizedStandardCompare($1.lastPathComponent) == .orderedAscending
         }
         
-        Logger.sourceNav.debug("Found \(sorted.count, privacy: .public) siblings in \(parentURL.lastPathComponent, privacy: .public)")
+        Logger.sourceNav.debug("Found \(sorted.count, privacy: .public) siblings in \(parentURL.lastPathComponent)")
         return sorted
     }
 }

--- a/Erimil/Erimil/ThumbnailGridView.swift
+++ b/Erimil/Erimil/ThumbnailGridView.swift
@@ -841,7 +841,7 @@ struct ThumbnailGridView: View {
         // CRITICAL: Check if this call is from a stale View instance
         // SwiftUI may trigger onAppear from old View instances with old imageSource
         guard imageSource.url == currentSourceURL else {
-            Logger.thumbnailGrid.debug("SKIP stale View call: \(entry.name, privacy: .public) (imageSource: \(imageSource.url.lastPathComponent, privacy: .public), current: \(currentSourceURL?.lastPathComponent ?? "nil"))")
+            Logger.thumbnailGrid.debug("SKIP stale View call: \(entry.name) (imageSource: \(imageSource.url.lastPathComponent), current: \(currentSourceURL?.lastPathComponent ?? "nil"))")
             return
         }
         
@@ -864,7 +864,7 @@ struct ThumbnailGridView: View {
             fullPath = entry.path  // FolderManager already has full path
         }
         
-        Logger.thumbnailGrid.debug("Starting for \(entryName, privacy: .public) from \(capturedSourceURL.lastPathComponent, privacy: .public), loadID: \(capturedLoadID, privacy: .public)")
+        Logger.thumbnailGrid.debug("Starting for \(entryName) from \(capturedSourceURL.lastPathComponent), loadID: \(capturedLoadID, privacy: .public)")
         
         DispatchQueue.global(qos: .userInitiated).async { [self] in
             // FIRST: Check validity on main thread BEFORE expensive operation
@@ -872,7 +872,7 @@ struct ThumbnailGridView: View {
             DispatchQueue.main.sync {
                 stillValid = (capturedLoadID == loadID && capturedSourceURL == currentSourceURL)
                 if !stillValid {
-                    Logger.thumbnailGrid.debug("SKIP async stale: \(entryName, privacy: .public)")
+                    Logger.thumbnailGrid.debug("SKIP async stale: \(entryName)")
                 }
             }
             
@@ -880,7 +880,7 @@ struct ThumbnailGridView: View {
             
             // Now generate thumbnail
             guard let thumbnail = currentSource.thumbnail(for: entry, maxSize: maxSize) else {
-                Logger.thumbnailGrid.error("Failed for: \(entryName, privacy: .public) from \(capturedSourceURL.lastPathComponent, privacy: .public)")
+                Logger.thumbnailGrid.error("Failed for: \(entryName) from \(capturedSourceURL.lastPathComponent)")
                 return
             }
             
@@ -890,17 +890,17 @@ struct ThumbnailGridView: View {
             DispatchQueue.main.async {
                 // Re-check validity after thumbnail generated
                 guard capturedLoadID == loadID else {
-                    Logger.thumbnailGrid.debug("Discarding stale thumbnail: \(entryName, privacy: .public) (loadID mismatch)")
+                    Logger.thumbnailGrid.debug("Discarding stale thumbnail: \(entryName) (loadID mismatch)")
                     return
                 }
                 
                 guard capturedSourceURL == currentSourceURL else {
-                    Logger.thumbnailGrid.debug("Discarding stale thumbnail: \(entryName, privacy: .public) (URL mismatch)")
+                    Logger.thumbnailGrid.debug("Discarding stale thumbnail: \(entryName) (URL mismatch)")
                     return
                 }
                 
                 guard entries.contains(where: { $0.path == entryPath }) else {
-                    Logger.thumbnailGrid.debug("Discarding thumbnail for removed entry: \(entryName, privacy: .public)")
+                    Logger.thumbnailGrid.debug("Discarding thumbnail for removed entry: \(entryName)")
                     return
                 }
                 
@@ -911,7 +911,7 @@ struct ThumbnailGridView: View {
                     contentHashes[entryPath] = hash
                 }
                 
-                Logger.thumbnailGrid.info("Success: \(entryName, privacy: .public)")
+                Logger.thumbnailGrid.info("Success: \(entryName)")
             }
         }
     }
@@ -1253,7 +1253,7 @@ struct ThumbnailGridView: View {
                 let targetFav = isRTL ? favoriteIndices.max() : favoriteIndices.min()
                 if let fav = targetFav {
                     focusedIndex = fav
-                    Logger.folder.debug("Ctrl+Z → \(isRTL ? "last" : "firs, privacy: .public)") favorite at \(fav)")
+                    Logger.folder.debug("Ctrl+Z → \(isRTL ? "last" : "first", privacy: .public) favorite at \(fav, privacy: .public)")
                 }
             } else {
                 let targetIndex = isRTL
@@ -1273,7 +1273,7 @@ struct ThumbnailGridView: View {
                 let targetFav = isRTL ? favoriteIndices.min() : favoriteIndices.max()
                 if let fav = targetFav {
                     focusedIndex = fav
-                    Logger.folder.debug("Ctrl+C → \(isRTL ? "first" : "las, privacy: .public)") favorite at \(fav)")
+                    Logger.folder.debug("Ctrl+C → \(isRTL ? "first" : "last", privacy: .public) favorite at \(fav, privacy: .public)")
                 }
             } else {
                 let targetIndex = isRTL
@@ -1316,7 +1316,7 @@ struct ThumbnailGridView: View {
     private func toggleSelection(_ entry: ImageEntry) {
         // In exclude mode, prevent selecting direct favorites (they're protected)
         if settings.selectionMode == .exclude && isDirectFavorite(entry) {
-            Logger.thumbnailGrid.debug("Blocked: \(entry.name, privacy: .public) is direct favorited (protected)")
+            Logger.thumbnailGrid.debug("Blocked: \(entry.name) is direct favorited (protected)")
             showProtectedFeedback(for: entry)
             return
         }
@@ -1448,7 +1448,7 @@ struct ThumbnailGridView: View {
     
     private func openPreview(at index: Int) {
         guard index >= 0 && index < entries.count else { return }
-        Logger.preview.debug("Opening preview at index: \(index, privacy: .public) - \(entries[index].name, privacy: .public)")
+        Logger.preview.debug("Opening preview at index: \(index, privacy: .public) - \(entries[index].name)")
         previewMode = .quickLook(index: index)
     }
     
@@ -1628,7 +1628,7 @@ struct BookmarkDividerView: View {
         let trimmed = editingName.trimmingCharacters(in: .whitespacesAndNewlines)
         if !trimmed.isEmpty && trimmed != bookmark.name {
             CacheManager.shared.updateBookmarkName(for: sourceURL, id: bookmark.id, name: trimmed)
-            Logger.bookmark.debug("Renamed '\(bookmark.name, privacy: .public)' → '\(trimmed, privacy: .public)'")
+            Logger.bookmark.debug("Renamed '\(bookmark.name)' → '\(trimmed)'")
             onNameChanged?()
         }
         isEditing = false
@@ -2989,7 +2989,7 @@ struct ViewerView: View {
                 let targetFav = isRTL ? favoriteIndices.max() : favoriteIndices.min()
                 if let fav = targetFav {
                     navigateTo(fav)
-                    Logger.viewer.debug("Ctrl+Z → \(isRTL ? "last" : "firs, privacy: .public)") favorite at \(fav)")
+                    Logger.viewer.debug("Ctrl+Z → \(isRTL ? "last" : "first", privacy: .public) favorite at \(fav, privacy: .public)")
                 }
             } else {
                 isRTL ? goToNextFavorite() : goToPreviousFavorite()
@@ -3003,7 +3003,7 @@ struct ViewerView: View {
                 let targetFav = isRTL ? favoriteIndices.min() : favoriteIndices.max()
                 if let fav = targetFav {
                     navigateTo(fav)
-                    Logger.viewer.debug("Ctrl+C → \(isRTL ? "first" : "las, privacy: .public)") favorite at \(fav)")
+                    Logger.viewer.debug("Ctrl+C → \(isRTL ? "first" : "last", privacy: .public) favorite at \(fav, privacy: .public)")
                 }
             } else {
                 isRTL ? goToPreviousFavorite() : goToNextFavorite()

--- a/Erimil/Erimil/ZIPEncodingDetector.swift
+++ b/Erimil/Erimil/ZIPEncodingDetector.swift
@@ -49,7 +49,7 @@ struct ZIPEncodingDetector {
     /// - Returns: Detected encoding type
     static func detect(for url: URL) -> DetectedEncoding {
         guard let fileHandle = try? FileHandle(forReadingFrom: url) else {
-            Logger.zipEncoding.error("Cannot open file: \(url.lastPathComponent, privacy: .public)")
+            Logger.zipEncoding.error("Cannot open file: \(url.lastPathComponent)")
             return .unknown
         }
         defer { try? fileHandle.close() }


### PR DESCRIPTION
…(#96)

Replace explicit  with  (implicit default) for
Logger interpolations containing file paths, URLs, and entry names. Apple's  masks these values in release builds while keeping them visible during debug builds via Console.app.

Changes:
- Remove .public from 80 interpolations across 14 files
- Fix 4 ternary truncation bugs from S037 (ThumbnailGridView.swift)
- Retain .public for index, count, size, bool, error, enum, and numeric values

Affected files:
  AppSettings, ArchiveManager, CacheManager, ContentView, FolderManager, ImagePrefetcher, ImageViewerCore, KeyHandling, PDFManager, SidebarView, SlideWindowController, SourceNavigator, ThumbnailGridView, ZIPEncodingDetector

Verified: debug build + Console.app confirm paths/names visible in debug, will be masked as <private> in release.