### PR TITLE
refactor: unify favorite navigation via NavigationHelper (#14)

### DIFF
--- a/Erimil/Erimil/ImagePreviewView.swift
+++ b/Erimil/Erimil/ImagePreviewView.swift
@@ -291,21 +291,35 @@ struct ImagePreviewView: View {
         }
     }
     
+    // #14: Unified favorite navigation via NavigationHelper
     private func goToPreviousFavorite() {
-        // #72: Use NavigationHelper for unified favorite navigation
-        guard let targetIndex = NavigationHelper.previousFavoriteIndex(
+        guard let targetIndex = NavigationHelper.previousFavoriteIndexSpreadAware(
             from: currentIndex,
-            favoriteIndices: favoriteIndices
+            favoriteIndices: favoriteIndices,
+            sourceURL: imageSource.url,
+            entries: entries
         ) else { return }
         
         currentIndex = targetIndex
     }
     
+    // #14: Unified favorite navigation via NavigationHelper
     private func goToNextFavorite() {
-        // #72: Use NavigationHelper for unified favorite navigation
-        guard let targetIndex = NavigationHelper.nextFavoriteIndex(
+        let isShowingSpread: Bool = {
+            guard AppSettings.shared.isSpreadModeEnabled,
+                  currentIndex + 1 < entries.count else { return false }
+            return !SpreadNavigationHelper.shouldShowSinglePage(
+                for: imageSource.url, at: currentIndex,
+                totalCount: entries.count, entries: entries
+            )
+        }()
+        
+        guard let targetIndex = NavigationHelper.nextFavoriteIndexSpreadAware(
             from: currentIndex,
-            favoriteIndices: favoriteIndices
+            favoriteIndices: favoriteIndices,
+            sourceURL: imageSource.url,
+            entries: entries,
+            isShowingSpread: isShowingSpread
         ) else { return }
         
         currentIndex = targetIndex

--- a/Erimil/Erimil/ImageViewerCore.swift
+++ b/Erimil/Erimil/ImageViewerCore.swift
@@ -176,38 +176,38 @@ struct ImageViewerCore: View {
     }
     
     /// Navigate to previous favorite (returns true if found and moved)
+    /// #14: Unified via NavigationHelper with spread-aware correction
     func goToPreviousFavorite() -> Bool {
-        guard !favoriteIndices.isEmpty else { return false }
-        
-        // Find the largest favorite index that is less than currentIndex
-        let previousFavorites = favoriteIndices.filter { $0 < currentIndex }
-        guard let targetIndex = previousFavorites.max() else {
-            // No favorite before current position - wrap to last favorite
-            if let lastFavorite = favoriteIndices.max(), lastFavorite != currentIndex {
-                currentIndex = lastFavorite
-                return true
-            }
-            return false
-        }
+        guard let targetIndex = NavigationHelper.previousFavoriteIndexSpreadAware(
+            from: currentIndex,
+            favoriteIndices: favoriteIndices,
+            sourceURL: imageSource.url,
+            entries: entries
+        ) else { return false }
         
         currentIndex = targetIndex
         return true
     }
     
     /// Navigate to next favorite (returns true if found and moved)
+    /// #14: Unified via NavigationHelper with spread-aware correction
     func goToNextFavorite() -> Bool {
-        guard !favoriteIndices.isEmpty else { return false }
+        let isShowingSpread: Bool = {
+            guard AppSettings.shared.isSpreadModeEnabled,
+                  currentIndex + 1 < entries.count else { return false }
+            return !SpreadNavigationHelper.shouldShowSinglePage(
+                for: imageSource.url, at: currentIndex,
+                totalCount: entries.count, entries: entries
+            )
+        }()
         
-        // Find the smallest favorite index that is greater than currentIndex
-        let nextFavorites = favoriteIndices.filter { $0 > currentIndex }
-        guard let targetIndex = nextFavorites.min() else {
-            // No favorite after current position - wrap to first favorite
-            if let firstFavorite = favoriteIndices.min(), firstFavorite != currentIndex {
-                currentIndex = firstFavorite
-                return true
-            }
-            return false
-        }
+        guard let targetIndex = NavigationHelper.nextFavoriteIndexSpreadAware(
+            from: currentIndex,
+            favoriteIndices: favoriteIndices,
+            sourceURL: imageSource.url,
+            entries: entries,
+            isShowingSpread: isShowingSpread
+        ) else { return false }
         
         currentIndex = targetIndex
         return true

--- a/Erimil/Erimil/KeyHandling.swift
+++ b/Erimil/Erimil/KeyHandling.swift
@@ -242,6 +242,69 @@ struct NavigationHelper {
         return nil
     }
     
+    // MARK: - Spread-Aware Favorite Navigation (#14: unified from 4 viewers)
+    
+    /// Find previous favorite index with spread leading-page correction (#104)
+    /// When a ★ is on a spread's partner page, adjusts to the leading page so
+    /// the spread pair is displayed correctly.
+    static func previousFavoriteIndexSpreadAware(
+        from currentIndex: Int,
+        favoriteIndices: Set<Int>,
+        sourceURL: URL,
+        entries: [ImageEntry],
+        wrap: Bool = true
+    ) -> Int? {
+        guard var targetIndex = previousFavoriteIndex(
+            from: currentIndex, favoriteIndices: favoriteIndices, wrap: wrap
+        ) else { return nil }
+        
+        // #104: If target is partner of a spread, adjust to leading page
+        if AppSettings.shared.isSpreadModeEnabled,
+           targetIndex > 0,
+           !SpreadNavigationHelper.shouldShowSinglePage(
+               for: sourceURL, at: targetIndex - 1,
+               totalCount: entries.count, entries: entries) {
+            targetIndex = targetIndex - 1
+        }
+        
+        return targetIndex
+    }
+    
+    /// Find next favorite index with spread skip correction (#104)
+    /// When the next ★ is on the partner page of the current spread (already visible),
+    /// skips to the following ★ instead.
+    static func nextFavoriteIndexSpreadAware(
+        from currentIndex: Int,
+        favoriteIndices: Set<Int>,
+        sourceURL: URL,
+        entries: [ImageEntry],
+        isShowingSpread: Bool,
+        wrap: Bool = true
+    ) -> Int? {
+        guard var targetIndex = nextFavoriteIndex(
+            from: currentIndex, favoriteIndices: favoriteIndices, wrap: wrap
+        ) else { return nil }
+        
+        // #104: Skip if target is partner of current spread (already visible)
+        if isShowingSpread && targetIndex == currentIndex + 1 {
+            guard let nextTarget = nextFavoriteIndex(
+                from: targetIndex, favoriteIndices: favoriteIndices, wrap: wrap
+            ) else { return nil }
+            targetIndex = nextTarget
+        }
+        
+        // #104: If target is partner of a spread, adjust to leading page
+        if AppSettings.shared.isSpreadModeEnabled,
+           targetIndex > 0,
+           !SpreadNavigationHelper.shouldShowSinglePage(
+               for: sourceURL, at: targetIndex - 1,
+               totalCount: entries.count, entries: entries) {
+            targetIndex = targetIndex - 1
+        }
+        
+        return targetIndex
+    }
+    
     /// Navigate to favorite in a direction with RTL support
     /// - Parameters:
     ///   - direction: Logical direction

--- a/Erimil/Erimil/SlideWindowController.swift
+++ b/Erimil/Erimil/SlideWindowController.swift
@@ -862,22 +862,15 @@ class SlideWindowController {
     }
     
     private func goToPreviousFavorite() {
-        // #72: Use NavigationHelper for unified favorite navigation
-        guard var targetIndex = NavigationHelper.previousFavoriteIndex(
-            from: currentIndex,
-            favoriteIndices: storedFavoriteIndices,
-            wrap: AppSettings.shared.loopWithinSource
-        ) else { return }
-        
-        // #104: If target is partner of a spread, adjust to leading page
-        if let source = storedImageSource,
-           AppSettings.shared.isSpreadModeEnabled,
-           targetIndex > 0,
-           !SpreadNavigationHelper.shouldShowSinglePage(
-               for: source.url, at: targetIndex - 1,
-               totalCount: storedEntries.count, entries: storedEntries) {
-            targetIndex = targetIndex - 1
-        }
+        // #14: Unified favorite navigation via NavigationHelper
+        guard let source = storedImageSource,
+              let targetIndex = NavigationHelper.previousFavoriteIndexSpreadAware(
+                from: currentIndex,
+                favoriteIndices: storedFavoriteIndices,
+                sourceURL: source.url,
+                entries: storedEntries,
+                wrap: AppSettings.shared.loopWithinSource
+              ) else { return }
         
         currentIndex = targetIndex
         storedOnIndexChange?(currentIndex)
@@ -885,27 +878,26 @@ class SlideWindowController {
     }
     
     private func goToNextFavorite() {
-        // #72: Use NavigationHelper for unified favorite navigation
-        guard var targetIndex = NavigationHelper.nextFavoriteIndex(
+        // #14: Unified favorite navigation via NavigationHelper
+        guard let source = storedImageSource else { return }
+        
+        let isShowingSpread: Bool = {
+            guard AppSettings.shared.isSpreadModeEnabled,
+                  currentIndex + 1 < storedEntries.count else { return false }
+            return !SpreadNavigationHelper.shouldShowSinglePage(
+                for: source.url, at: currentIndex,
+                totalCount: storedEntries.count, entries: storedEntries
+            )
+        }()
+        
+        guard let targetIndex = NavigationHelper.nextFavoriteIndexSpreadAware(
             from: currentIndex,
             favoriteIndices: storedFavoriteIndices,
+            sourceURL: source.url,
+            entries: storedEntries,
+            isShowingSpread: isShowingSpread,
             wrap: AppSettings.shared.loopWithinSource
         ) else { return }
-        
-        // #104: Skip if target is partner of current spread (no double-stop)
-        if let source = storedImageSource,
-           AppSettings.shared.isSpreadModeEnabled,
-           targetIndex == currentIndex + 1,
-           !SpreadNavigationHelper.shouldShowSinglePage(
-               for: source.url, at: currentIndex,
-               totalCount: storedEntries.count, entries: storedEntries) {
-            guard let nextTarget = NavigationHelper.nextFavoriteIndex(
-                from: targetIndex,
-                favoriteIndices: storedFavoriteIndices,
-                wrap: AppSettings.shared.loopWithinSource
-            ) else { return }
-            targetIndex = nextTarget
-        }
         
         currentIndex = targetIndex
         storedOnIndexChange?(currentIndex)

--- a/Erimil/Erimil/ThumbnailGridView.swift
+++ b/Erimil/Erimil/ThumbnailGridView.swift
@@ -2933,37 +2933,28 @@ struct ViewerView: View {
     }
     
     // #72: Favorite navigation (unified from Slide Mode)
+    // #14: Unified favorite navigation via NavigationHelper
     private func goToPreviousFavorite() {
-        guard var targetIndex = NavigationHelper.previousFavoriteIndex(
+        guard let targetIndex = NavigationHelper.previousFavoriteIndexSpreadAware(
             from: viewerIndex,
-            favoriteIndices: favoriteIndices
+            favoriteIndices: favoriteIndices,
+            sourceURL: imageSource.url,
+            entries: entries
         ) else { return }
-        
-        // #104: If target is partner of a spread, adjust to leading page
-        if targetIndex > 0,
-           !SpreadNavigationHelper.shouldShowSinglePage(
-               for: imageSource.url, at: targetIndex - 1,
-               totalCount: entries.count, entries: entries) {
-            targetIndex = targetIndex - 1
-        }
         
         Logger.viewer.debug("goToPreviousFavorite: \(viewerIndex, privacy: .public) → \(targetIndex, privacy: .public)")
         navigateTo(targetIndex)
     }
     
+    // #14: Unified favorite navigation via NavigationHelper
     private func goToNextFavorite() {
-        guard var targetIndex = NavigationHelper.nextFavoriteIndex(
+        guard let targetIndex = NavigationHelper.nextFavoriteIndexSpreadAware(
             from: viewerIndex,
-            favoriteIndices: favoriteIndices
+            favoriteIndices: favoriteIndices,
+            sourceURL: imageSource.url,
+            entries: entries,
+            isShowingSpread: isShowingSpread
         ) else { return }
-        
-        // #104: Skip if target is partner of current spread (no double-stop)
-        if isShowingSpread && targetIndex == viewerIndex + 1 {
-            guard let nextTarget = NavigationHelper.nextFavoriteIndex(
-                from: targetIndex, favoriteIndices: favoriteIndices
-            ) else { return }
-            targetIndex = nextTarget
-        }
         
         Logger.viewer.debug("goToNextFavorite: \(viewerIndex, privacy: .public) → \(targetIndex, privacy: .public)")
         navigateTo(targetIndex)


### PR DESCRIPTION
Extract spread-aware favorite navigation logic from 4 viewers into NavigationHelper.previousFavoriteIndexSpreadAware and nextFavoriteIndexSpreadAware. All viewers now delegate to the shared implementation with consistent #104 spread corrections.

Changed: KeyHandling.swift, ThumbnailGridView.swift, SlideWindowController.swift, ImagePreviewView.swift, ImageViewerCore.swift

----
See #14 