### PR TITLE
fix: prevent stale entries in Grid/Viewer Mode after source switch (#…

### DIFF
--- a/Erimil/Erimil/ContentView.swift
+++ b/Erimil/Erimil/ContentView.swift
@@ -230,6 +230,7 @@ private struct DetailContainerView: View {
                     sourceSelection.consumePrefetchedEntries(for: imageSource.url)
                 }
             )
+            .id(imageSource.url)  // S051: Force view recreation on source switch (#121)
             .onChange(of: shouldOpenSlideMode) { _, newValue in
                 if newValue {
                     shouldOpenSlideMode = false

--- a/Erimil/Erimil/ThumbnailGridView.swift
+++ b/Erimil/Erimil/ThumbnailGridView.swift
@@ -174,9 +174,17 @@ struct ThumbnailGridView: View {
     }
 
     var body: some View {
+        // S051: Guard against stale entries during source switch (#121)
+        // When imageSource changes, body re-evaluates BEFORE onChange fires loadSource().
+        // Without this guard, ViewerView/ThumbnailSidebarView would render with
+        // new imageSource + old entries for one frame, causing "Entry not found" errors.
+        let entriesAreStale = currentSourceURL != nil && currentSourceURL != imageSource.url
         Group {
-            // S013: Viewer Mode - full window image display
-            if case .viewer(let viewerIndex) = previewMode {
+            if entriesAreStale {
+                // Transient state: source changed, loadSource() pending from onChange
+                Color.black.ignoresSafeArea()
+            } else if case .viewer(let viewerIndex) = previewMode {
+                // S013: Viewer Mode - full window image display
                 viewerModeView(index: viewerIndex)
             } else {
                 thumbnailBrowserView


### PR DESCRIPTION
See #121 

- Add .id(imageSource.url) to ThumbnailGridView in DetailContainerView, forcing full @State reset on source change
- Add entriesAreStale guard in ThumbnailGridView.body to block rendering with mismatched imageSource + entries during SwiftUI re-evaluation gap

Root cause: SwiftUI reuses view identity (and @State) when the same branch of `if let` produces a new value. Old entries persisted for 1+ frames, causing "Entry not found" errors in thumbnail sidebar and stale thumbnails in Grid view.