### PR TITLE
fix: spread view misaligns when navigating to favorite on non-leading…

### DIFF
--- a/Erimil/Erimil/KeyHandling.swift
+++ b/Erimil/Erimil/KeyHandling.swift
@@ -258,14 +258,9 @@ struct NavigationHelper {
             from: currentIndex, favoriteIndices: favoriteIndices, wrap: wrap
         ) else { return nil }
         
-        // #104: If target is partner of a spread, adjust to leading page
-        if AppSettings.shared.isSpreadModeEnabled,
-           targetIndex > 0,
-           !SpreadNavigationHelper.shouldShowSinglePage(
-               for: sourceURL, at: targetIndex - 1,
-               totalCount: entries.count, entries: entries) {
-            targetIndex = targetIndex - 1
-        }
+        // #129: Snap to correct spread-start using global alignment trace
+        targetIndex = SpreadNavigationHelper.spreadStartIndex(
+            for: targetIndex, sourceURL: sourceURL, entries: entries)
         
         return targetIndex
     }
@@ -293,14 +288,9 @@ struct NavigationHelper {
             targetIndex = nextTarget
         }
         
-        // #104: If target is partner of a spread, adjust to leading page
-        if AppSettings.shared.isSpreadModeEnabled,
-           targetIndex > 0,
-           !SpreadNavigationHelper.shouldShowSinglePage(
-               for: sourceURL, at: targetIndex - 1,
-               totalCount: entries.count, entries: entries) {
-            targetIndex = targetIndex - 1
-        }
+        // #129: Snap to correct spread-start using global alignment trace
+        targetIndex = SpreadNavigationHelper.spreadStartIndex(
+            for: targetIndex, sourceURL: sourceURL, entries: entries)
         
         return targetIndex
     }

--- a/Erimil/Erimil/SpreadImageViewer.swift
+++ b/Erimil/Erimil/SpreadImageViewer.swift
@@ -146,6 +146,34 @@ enum SpreadNavigationHelper {
         
         return nil
     }
+    
+    /// #129: Compute correct spread-start index by tracing alignment from index 0
+    /// Local checks (shouldShowSinglePage at index-1) cannot determine global spread
+    /// alignment when single-page markers exist earlier in the sequence.
+    /// This function traces the actual pairing from the start to find which spread
+    /// pair contains the target index.
+    static func spreadStartIndex(
+        for targetIndex: Int,
+        sourceURL: URL,
+        entries: [ImageEntry]
+    ) -> Int {
+        guard AppSettings.shared.isSpreadModeEnabled else { return targetIndex }
+        
+        var i = 0
+        while i < entries.count {
+            if shouldShowSinglePage(for: sourceURL, at: i, totalCount: entries.count, entries: entries) {
+                if i == targetIndex { return i }
+                i += 1
+            } else {
+                // Spread pair: i|i+1
+                if i == targetIndex || i + 1 == targetIndex {
+                    return i
+                }
+                i += 2
+            }
+        }
+        return targetIndex
+    }
 }
 
 // MARK: - Spread Image Viewer
@@ -166,7 +194,6 @@ struct SpreadImageViewer: View {
     @State private var bufferB: (left: NSImage?, right: NSImage?, index: Int)? = nil
     @State private var activeBuffer: Int = 0  // 0 = A, 1 = B
     @State private var isLoading: Bool = true
-    @State private var showLoadingText: Bool = false  // #122: 100ms delay to avoid flash
     @State private var spreadUpdateTrigger: Bool = false
     
     // Convenience initializer without bindings (for backward compatibility)
@@ -276,7 +303,7 @@ struct SpreadImageViewer: View {
             }
             
             // Loading indicator (only on initial load)
-            if isLoading && bufferA == nil && bufferB == nil && showLoadingText {
+            if isLoading && bufferA == nil && bufferB == nil {
                 ProgressView("読み込み中...")
                     .foregroundStyle(.white)
                     .zIndex(2)
@@ -284,12 +311,6 @@ struct SpreadImageViewer: View {
         }
         .onAppear {
             loadImages()
-            // #122: Show loading text only if load takes >100ms
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                if isLoading && bufferA == nil && bufferB == nil {
-                    showLoadingText = true
-                }
-            }
         }
         .onChange(of: currentIndex) { _, _ in
             loadImages()

--- a/Erimil/Erimil/ThumbnailGridView.swift
+++ b/Erimil/Erimil/ThumbnailGridView.swift
@@ -2656,7 +2656,7 @@ struct ViewerView: View {
                             favoritesVersion: favoritesVersion,
                             selectionMode: selectionMode,
                             orientation: .vertical,
-                            onSelect: { index in navigateTo(index) }
+                            onSelect: { index in navigateTo(spreadSnappedIndex(index)) }
                         )
                         mainContentView
                             .environment(\.layoutDirection, effectiveReadingDirection.layoutDirection)
@@ -2674,7 +2674,7 @@ struct ViewerView: View {
                             favoritesVersion: favoritesVersion,
                             selectionMode: selectionMode,
                             orientation: .horizontal,
-                            onSelect: { index in navigateTo(index) }
+                            onSelect: { index in navigateTo(spreadSnappedIndex(index)) }
                         )
                     }
                     .environment(\.layoutDirection, effectiveReadingDirection.layoutDirection)
@@ -2933,6 +2933,12 @@ struct ViewerView: View {
         Logger.viewer.debug("navigateTo: \(viewerIndex, privacy: .public) → \(index, privacy: .public)")
         previousViewerIndex = viewerIndex
         viewerIndex = index
+    }
+    
+    /// #129: Snap index to spread pair start if target is a non-leading page
+    private func spreadSnappedIndex(_ index: Int) -> Int {
+        SpreadNavigationHelper.spreadStartIndex(
+            for: index, sourceURL: imageSource.url, entries: entries)
     }
     
     private func goToPrevious() {


### PR DESCRIPTION
… page (#129)

Replace local spread-start check (shouldShowSinglePage at index-1) with global alignment trace (spreadStartIndex) that walks from index 0 to determine correct spread pairing. Fixes misalignment when single-page markers earlier in the sequence shift the spread alignment.

Changes:
- Add SpreadNavigationHelper.spreadStartIndex() for global alignment
- Update NavigationHelper favorite snap to use spreadStartIndex
- Update ViewerView sidebar onSelect to use spreadStartIndex