### PR TITLE
fix: #131 empty source feedback in Viewer Mode and reopen flag cleanup

### DIFF
--- a/Erimil/Erimil/ThumbnailGridView.swift
+++ b/Erimil/Erimil/ThumbnailGridView.swift
@@ -861,14 +861,12 @@ struct ThumbnailGridView: View {
                 shouldReopenViewerMode = false
             }
             
-            if shouldReopenSlideMode && !entries.isEmpty {
+            if shouldReopenSlideMode {
+                // #131: Update Slide Mode even for empty entries (shows emptySourceView)
                 shouldReopenSlideMode = false
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                     reopenSlideModeAfterSwitch()
                 }
-            } else if shouldReopenSlideMode && entries.isEmpty {
-                // #131: Clear flag on empty source
-                shouldReopenSlideMode = false
             }
             return
         }
@@ -907,14 +905,12 @@ struct ThumbnailGridView: View {
                 }
                 
                 // S005: Reopen Slide Mode if flag is set
-                if shouldReopenSlideMode && !entries.isEmpty {
+                // #131: Update even for empty entries (shows emptySourceView)
+                if shouldReopenSlideMode {
                     shouldReopenSlideMode = false
                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                         reopenSlideModeAfterSwitch()
                     }
-                } else if shouldReopenSlideMode && entries.isEmpty {
-                    // #131: Clear flag on empty source
-                    shouldReopenSlideMode = false
                 }
                 
                 // #131: Clear Viewer Mode flag on empty source


### PR DESCRIPTION
See #131 

- Add empty source guard in Grid key handler (R/Ctrl+F/Enter)
- Add "画像がありません" display in ViewerView for empty entries
- Clear shouldReopenViewerMode/shouldReopenSlideMode on empty source across all paths (handleEntriesChange, loadSource, handleSlideModeReopen)
- Fixes black screen stuck on Viewer Mode → empty source switch

Note: Slide Mode empty source handling still under investigation