### PR TITLE
perf: remove double-tap gesture to eliminate selection tap delay

### DIFF
--- a/Erimil/Erimil/ThumbnailGridView.swift
+++ b/Erimil/Erimil/ThumbnailGridView.swift
@@ -564,10 +564,7 @@ struct ThumbnailGridView: View {
                                                     isLastViewed: item.index == lastViewedIndex  // #52
                                                 )
                                                 .id(item.index)
-                                                .onTapGesture(count: 2) {
-                                                    previewMode = .slideMode(index: item.index)
-                                                }
-                                                .onTapGesture(count: 1) {
+                                                .onTapGesture {
                                                     focusedIndex = item.index
                                                     toggleSelection(item.entry)
                                                 }


### PR DESCRIPTION
onTapGesture(count: 2) coexisting with onTapGesture(count: 1) caused ~200-300ms delay on single tap due to SwiftUI's double-tap timeout. Double-tap slideMode entry replaced by existing Ctrl+F shortcut.

Discovered during #126 investigation (S056).