### PR TITLE
feat(#154): render-gated navigation with Z/C favorite support

### DIFF
--- a/Erimil/Erimil/SlideWindowController.swift
+++ b/Erimil/Erimil/SlideWindowController.swift
@@ -27,6 +27,9 @@ class SlideWindowController {
     
     private var slideWindow: NSWindow?
     private var currentIndex: Int = 0
+    // #154: Render gate — prevent rapid key repeat from skipping pages
+    private var isNavigationGated: Bool = false
+    private var imageReadyObserver: NSObjectProtocol?
     
     /// Public getter for current index
     var getCurrentIndex: Int {
@@ -120,6 +123,18 @@ class SlideWindowController {
         isFavoritesMode = false
         showBookmarkList = false
         bookmarkListCursor = 0
+        isNavigationGated = false  // #154
+        
+        // #154: Listen for image ready signal to release navigation gate
+        if let existing = imageReadyObserver {
+            NotificationCenter.default.removeObserver(existing)
+        }
+        imageReadyObserver = NotificationCenter.default.addObserver(
+            forName: NSNotification.Name("SlideWindowImageReady"),
+            object: nil, queue: .main
+        ) { [weak self] _ in
+            self?.isNavigationGated = false
+        }
         
         // S008: Store callbacks and state for event monitor
         storedOnClose = onClose
@@ -228,6 +243,12 @@ class SlideWindowController {
         removeEventMonitor()
         removeMouseMonitor()  // #145
         slideHostingView = nil  // #145
+        
+        // #154: Remove image ready observer
+        if let observer = imageReadyObserver {
+            NotificationCenter.default.removeObserver(observer)
+            imageReadyObserver = nil
+        }
         
         // S008: Clear stored callbacks
         storedOnClose = nil
@@ -584,11 +605,11 @@ class SlideWindowController {
             } else if isFavoritesMode {
                 // #76: RTL inverts direction
                 Logger.slideWindow.debug("→ \(self.isRTL ? "Next" : "Previous") favorite (← in Favorites Mode)")
-                isRTL ? goToNextFavorite() : goToPreviousFavorite()
+                gatedNavigate { isRTL ? goToNextFavorite() : goToPreviousFavorite() }  // #154
                 return nil
             } else {
                 // #76: RTL inverts direction
-                isRTL ? goToNext() : goToPrevious()
+                gatedNavigate { isRTL ? goToNext() : goToPrevious() }  // #154
                 return nil
             }
             
@@ -605,11 +626,11 @@ class SlideWindowController {
             } else if isFavoritesMode {
                 // #76: RTL inverts direction
                 Logger.slideWindow.debug("→ \(self.isRTL ? "Previous" : "Next") favorite (→ in Favorites Mode)")
-                isRTL ? goToPreviousFavorite() : goToNextFavorite()
+                gatedNavigate { isRTL ? goToPreviousFavorite() : goToNextFavorite() }  // #154
                 return nil
             } else {
                 // #76: RTL inverts direction
-                isRTL ? goToPrevious() : goToNext()
+                gatedNavigate { isRTL ? goToPrevious() : goToNext() }  // #154
                 return nil
             }
         
@@ -625,10 +646,10 @@ class SlideWindowController {
                 return nil
             } else if isFavoritesMode {
                 Logger.slideWindow.debug("→ Previous favorite (↑ in Favorites Mode)")
-                goToPreviousFavorite()
+                gatedNavigate { goToPreviousFavorite() }  // #154
                 return nil
             } else {
-                goToPrevious()
+                gatedNavigate { goToPrevious() }  // #154
                 return nil
             }
             
@@ -644,10 +665,10 @@ class SlideWindowController {
                 return nil
             } else if isFavoritesMode {
                 Logger.slideWindow.debug("→ Next favorite (↓ in Favorites Mode)")
-                goToNextFavorite()
+                gatedNavigate { goToNextFavorite() }  // #154
                 return nil
             } else {
-                goToNext()
+                gatedNavigate { goToNext() }  // #154
                 return nil
             }
         
@@ -696,10 +717,10 @@ class SlideWindowController {
                     } else if isFavoritesMode {
                         // #76: RTL inverts direction
                         Logger.slideWindow.debug("→ \(self.isRTL ? "Next" : "Previous") favorite (A in Favorites Mode)")
-                        isRTL ? goToNextFavorite() : goToPreviousFavorite()
+                        gatedNavigate { isRTL ? goToNextFavorite() : goToPreviousFavorite() }  // #154
                     } else {
                         // #76: RTL inverts direction
-                        isRTL ? goToNext() : goToPrevious()
+                        gatedNavigate { isRTL ? goToNext() : goToPrevious() }  // #154
                     }
                     return nil
                     
@@ -728,10 +749,10 @@ class SlideWindowController {
                     } else if isFavoritesMode {
                         // #76: RTL inverts direction
                         Logger.slideWindow.debug("→ \(self.isRTL ? "Previous" : "Next") favorite (D in Favorites Mode)")
-                        isRTL ? goToPreviousFavorite() : goToNextFavorite()
+                        gatedNavigate { isRTL ? goToPreviousFavorite() : goToNextFavorite() }  // #154
                     } else {
                         // #76: RTL inverts direction
-                        isRTL ? goToPrevious() : goToNext()
+                        gatedNavigate { isRTL ? goToPrevious() : goToNext() }  // #154
                     }
                     return nil
                 
@@ -745,9 +766,9 @@ class SlideWindowController {
                         storedOnPreviousSource?()
                     } else if isFavoritesMode {
                         Logger.slideWindow.debug("→ Previous favorite (W in Favorites Mode)")
-                        goToPreviousFavorite()
+                        gatedNavigate { goToPreviousFavorite() }  // #154
                     } else {
-                        goToPrevious()
+                        gatedNavigate { goToPrevious() }  // #154
                     }
                     return nil
                     
@@ -773,9 +794,9 @@ class SlideWindowController {
                         storedOnNextSource?()
                     } else if isFavoritesMode {
                         Logger.slideWindow.debug("→ Next favorite (S in Favorites Mode)")
-                        goToNextFavorite()
+                        gatedNavigate { goToNextFavorite() }  // #154
                     } else {
-                        goToNext()
+                        gatedNavigate { goToNext() }  // #154
                     }
                     return nil
                 
@@ -896,7 +917,7 @@ class SlideWindowController {
                         }
                     } else {
                         Logger.slideWindow.debug("→ \(self.isRTL ? "Next" : "Previous") favorite (Z)")
-                        isRTL ? goToNextFavorite() : goToPreviousFavorite()
+                        gatedNavigate { isRTL ? goToNextFavorite() : goToPreviousFavorite() }  // #154
                     }
                     return nil
                     
@@ -914,7 +935,7 @@ class SlideWindowController {
                         }
                     } else {
                         Logger.slideWindow.debug("→ \(self.isRTL ? "Previous" : "Next") favorite (C)")
-                        isRTL ? goToPreviousFavorite() : goToNextFavorite()
+                        gatedNavigate { isRTL ? goToPreviousFavorite() : goToNextFavorite() }  // #154
                     }
                     return nil
                     
@@ -1035,6 +1056,14 @@ class SlideWindowController {
             storedOnIndexChange?(currentIndex)
             notifyViewOfIndexChange()
         }
+    }
+    
+    /// #154: Navigate with render gate — ensures each page displays at least one frame
+    private func gatedNavigate(_ action: () -> Void) {
+        guard !isNavigationGated else { return }
+        let before = currentIndex
+        action()
+        if currentIndex != before { isNavigationGated = true }
     }
     
     private func goToPreviousFavorite() {
@@ -1454,7 +1483,13 @@ struct SlideWindowView: View {
                     favoriteIndices: favoriteIndices,
                     reloadTrigger: isDeskewEnabled,  // #101: Force reload when deskew changes
                     isShowingSpread: $isShowingSpread,  // #115: Track for position indicator
-                    couldBeSpreadWithPrevious: .constant(false)
+                    couldBeSpreadWithPrevious: .constant(false),
+                    onImageReady: { _ in  // #154: Release navigation gate
+                        NotificationCenter.default.post(
+                            name: NSNotification.Name("SlideWindowImageReady"),
+                            object: nil
+                        )
+                    }
                 )
                 .environment(\.layoutDirection, effectiveReadingDirection.layoutDirection)  // #150: RTL spread inversion
             }

--- a/Erimil/Erimil/SpreadImageViewer.swift
+++ b/Erimil/Erimil/SpreadImageViewer.swift
@@ -186,6 +186,9 @@ struct SpreadImageViewer: View {
     @Binding var isShowingSpread: Bool  // #67: Notify parent if currently showing spread
     @Binding var couldBeSpreadWithPrevious: Bool  // #67: Could form spread with previous page
     
+    // #154: Callback when image buffer swap completes (render gate for rapid navigation)
+    var onImageReady: ((Int) -> Void)? = nil
+    
     // Double buffering: two layers, switch instantly when ready
     @State private var bufferA: (left: NSImage?, right: NSImage?, index: Int)? = nil
     @State private var bufferB: (left: NSImage?, right: NSImage?, index: Int)? = nil
@@ -199,7 +202,8 @@ struct SpreadImageViewer: View {
         entries: [ImageEntry],
         currentIndex: Binding<Int>,
         favoriteIndices: Set<Int>,
-        reloadTrigger: Bool = false
+        reloadTrigger: Bool = false,
+        onImageReady: ((Int) -> Void)? = nil  // #154
     ) {
         self.imageSource = imageSource
         self.entries = entries
@@ -208,6 +212,7 @@ struct SpreadImageViewer: View {
         self.reloadTrigger = reloadTrigger
         self._isShowingSpread = .constant(false)
         self._couldBeSpreadWithPrevious = .constant(false)
+        self.onImageReady = onImageReady  // #154
     }
     
     // Full initializer with bindings
@@ -218,7 +223,8 @@ struct SpreadImageViewer: View {
         favoriteIndices: Set<Int>,
         reloadTrigger: Bool = false,
         isShowingSpread: Binding<Bool>,
-        couldBeSpreadWithPrevious: Binding<Bool>
+        couldBeSpreadWithPrevious: Binding<Bool>,
+        onImageReady: ((Int) -> Void)? = nil  // #154
     ) {
         self.imageSource = imageSource
         self.entries = entries
@@ -227,6 +233,7 @@ struct SpreadImageViewer: View {
         self.reloadTrigger = reloadTrigger
         self._isShowingSpread = isShowingSpread
         self._couldBeSpreadWithPrevious = couldBeSpreadWithPrevious
+        self.onImageReady = onImageReady  // #154
     }
     
     /// Check if spread mode is enabled
@@ -477,6 +484,7 @@ struct SpreadImageViewer: View {
                         couldBeSpreadWithPrevious = canSpreadWithPrev
                         Logger.spread.debug("Single display at \(capturedIndex, privacy: .public), couldBeSpreadWithPrevious: \(canSpreadWithPrev, privacy: .public)")
                     }
+                    onImageReady?(capturedIndex)  // #154: Render gate release
                     return
                 }
                 
@@ -516,6 +524,7 @@ struct SpreadImageViewer: View {
                                 couldBeSpreadWithPrevious = canSpreadWithPrev
                                 Logger.spread.debug("Single (right wide) at \(capturedIndex, privacy: .public), couldBeSpreadWithPrevious: \(canSpreadWithPrev, privacy: .public)")
                             }
+                            onImageReady?(capturedIndex)  // #154: Render gate release
                         } else {
                             // Both are portrait - show spread
                             withTransaction(Transaction(animation: nil)) {
@@ -531,6 +540,7 @@ struct SpreadImageViewer: View {
                                 couldBeSpreadWithPrevious = false  // Already in spread
                                 Logger.spread.debug("Spread display at \(capturedIndex, privacy: .public)|\(capturedIndex+1, privacy: .public)")
                             }
+                            onImageReady?(capturedIndex)  // #154: Render gate release
                         }
                     }
                 }

--- a/Erimil/Erimil/ThumbnailGridView.swift
+++ b/Erimil/Erimil/ThumbnailGridView.swift
@@ -2760,6 +2760,9 @@ struct ViewerView: View {
     // #101: Deskew state
     @State private var isDeskewEnabled: Bool = false
     
+    // #154: Render gate — prevent rapid key repeat from skipping pages
+    @State private var isNavigationGated: Bool = false
+    
     /// #54: Effective reading direction for this source
     private var effectiveReadingDirection: ReadingDirection {
         CacheManager.shared.getEffectiveReadingDirection(for: imageSource.url)
@@ -2946,7 +2949,8 @@ struct ViewerView: View {
                         favoriteIndices: favoriteIndices,
                         reloadTrigger: spreadUpdateTrigger,
                         isShowingSpread: $isShowingSpread,
-                        couldBeSpreadWithPrevious: $couldBeSpreadWithPrevious
+                        couldBeSpreadWithPrevious: $couldBeSpreadWithPrevious,
+                        onImageReady: { _ in isNavigationGated = false }  // #154
                     )
                     
                     // Navigation hints (left/right edges) - #67: Spread-aware
@@ -3128,6 +3132,14 @@ struct ViewerView: View {
         Logger.viewer.debug("navigateTo: \(viewerIndex, privacy: .public) → \(index, privacy: .public)")
         previousViewerIndex = viewerIndex
         viewerIndex = index
+    }
+    
+    /// #154: Navigate with render gate — ensures each page displays at least one frame
+    private func gatedNavigate(_ action: () -> Void) {
+        guard !isNavigationGated else { return }
+        let before = viewerIndex
+        action()
+        if viewerIndex != before { isNavigationGated = true }
     }
     
     /// #129: Snap index to spread pair start if target is a non-leading page
@@ -3338,7 +3350,7 @@ struct ViewerView: View {
                 onRequestPreviousSource?()
             } else {
                 // #76: RTL inverts direction
-                isRTL ? goToNext() : goToPrevious()
+                gatedNavigate { isRTL ? goToNext() : goToPrevious() }  // #154
             }
             return true
             
@@ -3355,7 +3367,7 @@ struct ViewerView: View {
                 onRequestNextSource?()
             } else {
                 // #76: RTL inverts direction
-                isRTL ? goToPrevious() : goToNext()
+                gatedNavigate { isRTL ? goToPrevious() : goToNext() }  // #154
             }
             return true
         
@@ -3368,7 +3380,7 @@ struct ViewerView: View {
             } else if event.modifierFlags.contains(.control) {
                 onRequestPreviousSource?()
             } else {
-                goToPrevious()
+                gatedNavigate { goToPrevious() }  // #154
             }
             return true
             
@@ -3381,7 +3393,7 @@ struct ViewerView: View {
             } else if event.modifierFlags.contains(.control) {
                 onRequestNextSource?()
             } else {
-                goToNext()
+                gatedNavigate { goToNext() }  // #154
             }
             return true
 
@@ -3437,7 +3449,7 @@ struct ViewerView: View {
                 Logger.viewer.debug("Ctrl+A → \(isRTL ? "end" : "start")")
             } else {
                 // #76: RTL inverts direction
-                isRTL ? goToNext() : goToPrevious()
+                gatedNavigate { isRTL ? goToNext() : goToPrevious() }  // #154
             }
             return true
             
@@ -3474,7 +3486,7 @@ struct ViewerView: View {
                 Logger.viewer.debug("Ctrl+D → \(isRTL ? "start" : "end")")
             } else {
                 // #76: RTL inverts direction
-                isRTL ? goToPrevious() : goToNext()
+                gatedNavigate { isRTL ? goToPrevious() : goToNext() }  // #154
             }
             return true
         
@@ -3487,7 +3499,7 @@ struct ViewerView: View {
             } else if event.modifierFlags.contains(.control) {
                 onRequestPreviousSource?()
             } else {
-                goToPrevious()
+                gatedNavigate { goToPrevious() }  // #154
             }
             return true
             
@@ -3512,7 +3524,7 @@ struct ViewerView: View {
             } else if event.modifierFlags.contains(.control) {
                 onRequestNextSource?()
             } else {
-                goToNext()
+                gatedNavigate { goToNext() }  // #154
             }
             return true
         
@@ -3695,7 +3707,7 @@ struct ViewerView: View {
                     Logger.viewer.debug("Ctrl+Z → \(isRTL ? "last" : "first", privacy: .public) favorite at \(fav, privacy: .public)")
                 }
             } else {
-                isRTL ? goToNextFavorite() : goToPreviousFavorite()
+                gatedNavigate { isRTL ? goToNextFavorite() : goToPreviousFavorite() }  // #154
             }
             return true
             
@@ -3716,7 +3728,7 @@ struct ViewerView: View {
                     Logger.viewer.debug("Ctrl+C → \(isRTL ? "first" : "last", privacy: .public) favorite at \(fav, privacy: .public)")
                 }
             } else {
-                isRTL ? goToPreviousFavorite() : goToNextFavorite()
+                gatedNavigate { isRTL ? goToPreviousFavorite() : goToNextFavorite() }  // #154
             }
             return true
             


### PR DESCRIPTION
- Add onImageReady callback to SpreadImageViewer (fires on buffer swap)
- Gate plain A/D/W/S, arrow keys, Z/C in Viewer Mode (ViewerView)
- Gate plain A/D/W/S, arrow keys, Z/C, and favorites mode in Slide Mode
- Modified keys (Ctrl+, Shift+, Cmd+) bypass gate
- Gate clears when full image completes buffer swap — no artificial delay
- Navigation rate adapts to actual image load speed

Files: SpreadImageViewer.swift, ThumbnailGridView.swift, SlideWindowController.swift Closes #154