### PR TITLE
fix(#161): prevent data loss on export with existing destination

### DIFF
--- a/Erimil/Erimil/ArchiveManager.swift
+++ b/Erimil/Erimil/ArchiveManager.swift
@@ -276,75 +276,78 @@ class ArchiveManager: ImageSource {
     
     /// Export excluding specified paths
     /// Reference: https://github.com/weichsel/ZIPFoundation#adding-and-removing-entries
+    /// Uses atomic safe export to prevent data loss when destination == source (#161)
     func exportOptimized(excluding excludedPaths: Set<String>, to destinationURL: URL) throws {
         Logger.archive.info("exportOptimized called")
         Logger.archive.debug("Excluded paths: \(excludedPaths)")
         
-        guard let sourceArchive = openArchive() else {
-            Logger.archive.error("Failed to open source archive")
-            throw ArchiveError.cannotOpenSource
-        }
-        Logger.archive.debug("Source archive opened")
-        
-        guard let destinationArchive = try? Archive(url: destinationURL, accessMode: .create) else {
-            Logger.archive.error("Failed to create destination archive at: \(destinationURL.path)")
-            throw ArchiveError.cannotCreateDestination
-        }
-        Logger.archive.debug("Destination archive created")
-        
-        let encoding = getPathEncoding()
-        
-        for entry in sourceArchive {
-            let path = encoding != nil ? entry.path(using: encoding!) : entry.path
-            
-            if excludedPaths.contains(path) {
-                Logger.archive.debug("Excluding: \(path)")
-                continue
+        try ExportUtilities.safeExport(to: destinationURL) { tempURL in
+            guard let sourceArchive = openArchive() else {
+                Logger.archive.error("Failed to open source archive")
+                throw ArchiveError.cannotOpenSource
             }
+            Logger.archive.debug("Source archive opened")
             
-            if path.contains("__MACOSX/") {
-                Logger.archive.debug("Skipping __MACOSX: \(path)")
-                continue
+            guard let destinationArchive = try? Archive(url: tempURL, accessMode: .create) else {
+                Logger.archive.error("Failed to create destination archive at: \(tempURL.path)")
+                throw ArchiveError.cannotCreateDestination
             }
+            Logger.archive.debug("Destination archive created (temp)")
             
-            if entry.type == .directory {
-                Logger.archive.debug("Skipping directory: \(path)")
-                continue
-            }
+            let encoding = getPathEncoding()
             
-            Logger.archive.debug("Copying: \(path)")
-            
-            var entryData = Data()
-            do {
-                _ = try sourceArchive.extract(entry) { data in
-                    entryData.append(data)
+            for entry in sourceArchive {
+                let path = encoding != nil ? entry.path(using: encoding!) : entry.path
+                
+                if excludedPaths.contains(path) {
+                    Logger.archive.debug("Excluding: \(path)")
+                    continue
                 }
-                Logger.archive.debug("  Extracted: \(entryData.count, privacy: .public) bytes")
-            } catch {
-                Logger.archive.error("  Extract failed: \(error, privacy: .public)")
-                continue
+                
+                if path.contains("__MACOSX/") {
+                    Logger.archive.debug("Skipping __MACOSX: \(path)")
+                    continue
+                }
+                
+                if entry.type == .directory {
+                    Logger.archive.debug("Skipping directory: \(path)")
+                    continue
+                }
+                
+                Logger.archive.debug("Copying: \(path)")
+                
+                var entryData = Data()
+                do {
+                    _ = try sourceArchive.extract(entry) { data in
+                        entryData.append(data)
+                    }
+                    Logger.archive.debug("  Extracted: \(entryData.count, privacy: .public) bytes")
+                } catch {
+                    Logger.archive.error("  Extract failed: \(error, privacy: .public)")
+                    continue
+                }
+                
+                do {
+                    // Write with correctly decoded path (UTF-8 in destination)
+                    try destinationArchive.addEntry(
+                        with: path,
+                        type: entry.type,
+                        uncompressedSize: Int64(entryData.count),
+                        provider: { position, size in
+                            let start = Int(position)
+                            let end = min(start + size, entryData.count)
+                            return entryData.subdata(in: start..<end)
+                        }
+                    )
+                    Logger.archive.debug("  Added to destination")
+                } catch {
+                    Logger.archive.error("  Add failed: \(error, privacy: .public)")
+                    continue
+                }
             }
             
-            do {
-                // Write with correctly decoded path (UTF-8 in destination)
-                try destinationArchive.addEntry(
-                    with: path,
-                    type: entry.type,
-                    uncompressedSize: Int64(entryData.count),
-                    provider: { position, size in
-                        let start = Int(position)
-                        let end = min(start + size, entryData.count)
-                        return entryData.subdata(in: start..<end)
-                    }
-                )
-                Logger.archive.debug("  Added to destination")
-            } catch {
-                Logger.archive.error("  Add failed: \(error, privacy: .public)")
-                continue
-            }
+            Logger.archive.info("Export completed successfully")
         }
-        
-        Logger.archive.info("Export completed successfully")
     }
 }
 

--- a/Erimil/Erimil/ExportUtilities.swift
+++ b/Erimil/Erimil/ExportUtilities.swift
@@ -1,0 +1,66 @@
+//
+//  ExportUtilities.swift
+//  Erimil
+//
+//  Atomic-safe export utility to prevent data loss when
+//  destination path equals source path (#161)
+//
+
+import Foundation
+import AppKit
+import os
+
+enum ExportUtilities {
+    
+    /// Write to temporary file, then move to destination.
+    ///
+    /// Caller must ensure `destinationURL` does not already exist (use `guardDestination` first).
+    /// - `writeOperation` receives a temporary URL — perform all I/O there.
+    /// - On success: moves temp → destination.
+    /// - On failure: temp file is cleaned up, no side effects.
+    ///
+    /// The temp file is created in the same directory as destination to ensure
+    /// atomic rename on the same filesystem. Name starts with "." to hide from Finder.
+    ///
+    /// - Parameters:
+    ///   - destinationURL: Final output path (must not exist)
+    ///   - writeOperation: Closure that writes output to the provided temp URL
+    static func safeExport(
+        to destinationURL: URL,
+        writeOperation: (URL) throws -> Void
+    ) throws {
+        let tempFileName = ".\(destinationURL.lastPathComponent).tmp_\(ProcessInfo.processInfo.globallyUniqueString)"
+        let tempURL = destinationURL
+            .deletingLastPathComponent()
+            .appendingPathComponent(tempFileName)
+        
+        Logger.export.debug("safeExport: temp=\(tempURL.lastPathComponent) → dest=\(destinationURL.lastPathComponent)")
+        
+        do {
+            try writeOperation(tempURL)
+            
+            try FileManager.default.moveItem(at: tempURL, to: destinationURL)
+            Logger.export.info("safeExport: completed → \(destinationURL.lastPathComponent)")
+        } catch {
+            // Cleanup temp file on any failure
+            try? FileManager.default.removeItem(at: tempURL)
+            Logger.export.error("safeExport: failed — \(error.localizedDescription, privacy: .public)")
+            throw error
+        }
+    }
+    
+    /// Check that destination does not already exist.
+    /// Returns localized error message if blocked, nil if safe to proceed.
+    static func guardDestination(_ url: URL) -> String? {
+        if FileManager.default.fileExists(atPath: url.path) {
+            return "「\(url.lastPathComponent)」は既に存在します。別の名前を指定してください。"
+        }
+        return nil
+    }
+}
+
+// MARK: - Logger Extension
+
+extension Logger {
+    static let export = Logger(subsystem: "com.erimil.app", category: "Export")
+}

--- a/Erimil/Erimil/FolderManager.swift
+++ b/Erimil/Erimil/FolderManager.swift
@@ -177,33 +177,36 @@ class FolderManager: ImageSource {
     // MARK: - Folder Operations
     
     /// Create ZIP from selected images (excluding excludedPaths)
+    /// Uses atomic safe export to prevent data loss (#161)
     func createZip(excluding excludedPaths: Set<String>, to destinationURL: URL) throws {
         Logger.folder.info("createZip called")
         Logger.folder.debug("Excluded paths: \(excludedPaths)")
         
-        guard let archive = Archive(url: destinationURL, accessMode: .create) else {
-            throw FolderError.cannotCreateZip
-        }
-        
-        let entries = listImageEntries()
-        
-        for entry in entries {
-            if excludedPaths.contains(entry.path) {
-                Logger.folder.debug("Excluding: \(entry.name)")
-                continue
+        try ExportUtilities.safeExport(to: destinationURL) { tempURL in
+            guard let archive = Archive(url: tempURL, accessMode: .create) else {
+                throw FolderError.cannotCreateZip
             }
             
-            let fileURL = URL(fileURLWithPath: entry.path)
+            let entries = listImageEntries()
             
-            do {
-                try archive.addEntry(with: entry.name, relativeTo: fileURL.deletingLastPathComponent())
-                Logger.folder.debug("Added: \(entry.name)")
-            } catch {
-                Logger.folder.error("Failed to add \(entry.name): \(error, privacy: .public)")
+            for entry in entries {
+                if excludedPaths.contains(entry.path) {
+                    Logger.folder.debug("Excluding: \(entry.name)")
+                    continue
+                }
+                
+                let fileURL = URL(fileURLWithPath: entry.path)
+                
+                do {
+                    try archive.addEntry(with: entry.name, relativeTo: fileURL.deletingLastPathComponent())
+                    Logger.folder.debug("Added: \(entry.name)")
+                } catch {
+                    Logger.folder.error("Failed to add \(entry.name): \(error, privacy: .public)")
+                }
             }
+            
+            Logger.folder.info("ZIP creation completed")
         }
-        
-        Logger.folder.info("ZIP creation completed")
     }
     
     /// Move selected images to Trash

--- a/Erimil/Erimil/PDFManager.swift
+++ b/Erimil/Erimil/PDFManager.swift
@@ -193,6 +193,7 @@ class PDFManager: ImageSource {
     // MARK: - Export Operations (#100)
     
     /// Export PDF excluding specified pages, creating an optimized PDF
+    /// Uses atomic safe export to prevent data loss when destination == source (#161)
     /// - Parameters:
     ///   - pathsToRemove: Set of page paths to exclude (e.g., "page_001", "page_003")
     ///   - outputURL: Destination URL for the optimized PDF
@@ -203,34 +204,36 @@ class PDFManager: ImageSource {
             throw PDFExportError.cannotOpenDocument
         }
         
-        let newDoc = PDFDocument()
-        var insertIndex = 0
-        
-        for i in 0..<sourceDoc.pageCount {
-            let pagePath = String(format: "page_%03d", i + 1)
-            if pathsToRemove.contains(pagePath) {
-                Logger.pdf.debug("Excluding page \(i + 1, privacy: .public)")
-                continue
+        try ExportUtilities.safeExport(to: outputURL) { tempURL in
+            let newDoc = PDFDocument()
+            var insertIndex = 0
+            
+            for i in 0..<sourceDoc.pageCount {
+                let pagePath = String(format: "page_%03d", i + 1)
+                if pathsToRemove.contains(pagePath) {
+                    Logger.pdf.debug("Excluding page \(i + 1, privacy: .public)")
+                    continue
+                }
+                
+                guard let page = sourceDoc.page(at: i) else {
+                    Logger.pdf.error("Failed to get page at index \(i, privacy: .public)")
+                    continue
+                }
+                
+                newDoc.insert(page, at: insertIndex)
+                insertIndex += 1
             }
             
-            guard let page = sourceDoc.page(at: i) else {
-                Logger.pdf.error("Failed to get page at index \(i, privacy: .public)")
-                continue
+            guard insertIndex > 0 else {
+                throw PDFExportError.noRemainingPages
             }
             
-            newDoc.insert(page, at: insertIndex)
-            insertIndex += 1
+            guard newDoc.write(to: tempURL) else {
+                throw PDFExportError.writeFailed(tempURL)
+            }
+            
+            Logger.pdf.info("Exported _opt.pdf: \(insertIndex, privacy: .public) pages to \(outputURL.lastPathComponent)")
         }
-        
-        guard insertIndex > 0 else {
-            throw PDFExportError.noRemainingPages
-        }
-        
-        guard newDoc.write(to: outputURL) else {
-            throw PDFExportError.writeFailed(outputURL)
-        }
-        
-        Logger.pdf.info("Exported _opt.pdf: \(insertIndex, privacy: .public) pages to \(outputURL.lastPathComponent)")
     }
     
     /// Export PDF pages as individual PNG images at 300dpi
@@ -323,6 +326,7 @@ class PDFManager: ImageSource {
     }
     
     /// Export PDF pages as PNG images packaged in a ZIP archive
+    /// Uses atomic safe export to prevent data loss (#161)
     /// - Parameters:
     ///   - pathsToRemove: Set of page paths to exclude
     ///   - outputURL: Destination URL for the ZIP file (e.g., "sample_png.zip")
@@ -335,82 +339,86 @@ class PDFManager: ImageSource {
             throw PDFExportError.cannotOpenDocument
         }
         
-        // Create ZIP archive
-        guard let archive = Archive(url: outputURL, accessMode: .create) else {
-            throw PDFExportError.writeFailed(outputURL)
-        }
-        
-        let dpi: CGFloat = 300.0
-        let scaleFactor = dpi / 72.0
         var exportedCount = 0
         
-        for i in 0..<sourceDoc.pageCount {
-            let pagePath = String(format: "page_%03d", i + 1)
-            if pathsToRemove.contains(pagePath) {
-                continue
+        try ExportUtilities.safeExport(to: outputURL) { tempURL in
+            // Create ZIP archive
+            guard let archive = Archive(url: tempURL, accessMode: .create) else {
+                throw PDFExportError.writeFailed(tempURL)
             }
             
-            guard let page = sourceDoc.page(at: i) else {
-                Logger.pdf.error("PNG ZIP export: failed to get page \(i + 1, privacy: .public)")
-                continue
-            }
+            let dpi: CGFloat = 300.0
+            let scaleFactor = dpi / 72.0
             
-            let mediaBox = page.bounds(for: .mediaBox)
-            let renderWidth = Int(mediaBox.width * scaleFactor)
-            let renderHeight = Int(mediaBox.height * scaleFactor)
-            
-            guard let bitmapRep = NSBitmapImageRep(
-                bitmapDataPlanes: nil,
-                pixelsWide: renderWidth,
-                pixelsHigh: renderHeight,
-                bitsPerSample: 8,
-                samplesPerPixel: 4,
-                hasAlpha: true,
-                isPlanar: false,
-                colorSpaceName: .deviceRGB,
-                bytesPerRow: 0,
-                bitsPerPixel: 0
-            ) else {
-                Logger.pdf.error("PNG ZIP export: failed to create bitmap for page \(i + 1, privacy: .public)")
-                continue
-            }
-            
-            NSGraphicsContext.saveGraphicsState()
-            let context = NSGraphicsContext(bitmapImageRep: bitmapRep)
-            NSGraphicsContext.current = context
-            
-            if let cgContext = context?.cgContext {
-                cgContext.setFillColor(NSColor.white.cgColor)
-                cgContext.fill(CGRect(x: 0, y: 0, width: renderWidth, height: renderHeight))
-                cgContext.scaleBy(x: scaleFactor, y: scaleFactor)
-                page.draw(with: .mediaBox, to: cgContext)
-            }
-            
-            NSGraphicsContext.restoreGraphicsState()
-            
-            guard let pngData = bitmapRep.representation(using: .png, properties: [:]) else {
-                Logger.pdf.error("PNG ZIP export: failed to create PNG data for page \(i + 1, privacy: .public)")
-                continue
-            }
-            
-            // Original page number preserved (飛び番)
-            let fileName = String(format: "page_%03d.png", i + 1)
-            try archive.addEntry(
-                with: fileName,
-                type: .file,
-                uncompressedSize: Int64(pngData.count),
-                provider: { position, size in
-                    pngData.subdata(in: Int(position)..<Int(position) + size)
+            for i in 0..<sourceDoc.pageCount {
+                let pagePath = String(format: "page_%03d", i + 1)
+                if pathsToRemove.contains(pagePath) {
+                    continue
                 }
-            )
-            exportedCount += 1
+                
+                guard let page = sourceDoc.page(at: i) else {
+                    Logger.pdf.error("PNG ZIP export: failed to get page \(i + 1, privacy: .public)")
+                    continue
+                }
+                
+                let mediaBox = page.bounds(for: .mediaBox)
+                let renderWidth = Int(mediaBox.width * scaleFactor)
+                let renderHeight = Int(mediaBox.height * scaleFactor)
+                
+                guard let bitmapRep = NSBitmapImageRep(
+                    bitmapDataPlanes: nil,
+                    pixelsWide: renderWidth,
+                    pixelsHigh: renderHeight,
+                    bitsPerSample: 8,
+                    samplesPerPixel: 4,
+                    hasAlpha: true,
+                    isPlanar: false,
+                    colorSpaceName: .deviceRGB,
+                    bytesPerRow: 0,
+                    bitsPerPixel: 0
+                ) else {
+                    Logger.pdf.error("PNG ZIP export: failed to create bitmap for page \(i + 1, privacy: .public)")
+                    continue
+                }
+                
+                NSGraphicsContext.saveGraphicsState()
+                let context = NSGraphicsContext(bitmapImageRep: bitmapRep)
+                NSGraphicsContext.current = context
+                
+                if let cgContext = context?.cgContext {
+                    cgContext.setFillColor(NSColor.white.cgColor)
+                    cgContext.fill(CGRect(x: 0, y: 0, width: renderWidth, height: renderHeight))
+                    cgContext.scaleBy(x: scaleFactor, y: scaleFactor)
+                    page.draw(with: .mediaBox, to: cgContext)
+                }
+                
+                NSGraphicsContext.restoreGraphicsState()
+                
+                guard let pngData = bitmapRep.representation(using: .png, properties: [:]) else {
+                    Logger.pdf.error("PNG ZIP export: failed to create PNG data for page \(i + 1, privacy: .public)")
+                    continue
+                }
+                
+                // Original page number preserved (飛び番)
+                let fileName = String(format: "page_%03d.png", i + 1)
+                try archive.addEntry(
+                    with: fileName,
+                    type: .file,
+                    uncompressedSize: Int64(pngData.count),
+                    provider: { position, size in
+                        pngData.subdata(in: Int(position)..<Int(position) + size)
+                    }
+                )
+                exportedCount += 1
+            }
+            
+            guard exportedCount > 0 else {
+                throw PDFExportError.noRemainingPages
+            }
+            
+            Logger.pdf.info("Exported \(exportedCount, privacy: .public) PNG pages to ZIP: \(outputURL.lastPathComponent)")
         }
         
-        guard exportedCount > 0 else {
-            throw PDFExportError.noRemainingPages
-        }
-        
-        Logger.pdf.info("Exported \(exportedCount, privacy: .public) PNG pages to ZIP: \(outputURL.lastPathComponent)")
         return exportedCount
     }
 }

--- a/Erimil/Erimil/ThumbnailGridView.swift
+++ b/Erimil/Erimil/ThumbnailGridView.swift
@@ -1720,7 +1720,12 @@ struct ThumbnailGridView: View {
             return
         }
         
-        try? FileManager.default.removeItem(at: outputURL)
+        // #161: Block if destination already exists
+        if let reason = ExportUtilities.guardDestination(outputURL) {
+            exportMessage = reason
+            showExportError = true
+            return
+        }
         
         do {
             try archiveManager.exportOptimized(excluding: pathsToRemove, to: outputURL)
@@ -1771,7 +1776,12 @@ struct ThumbnailGridView: View {
             return
         }
         
-        try? FileManager.default.removeItem(at: outputURL)
+        // #161: Block if destination already exists
+        if let reason = ExportUtilities.guardDestination(outputURL) {
+            exportMessage = reason
+            showExportError = true
+            return
+        }
         
         do {
             try folderManager.createZip(excluding: pathsToRemove, to: outputURL)
@@ -1840,7 +1850,12 @@ struct ThumbnailGridView: View {
             return
         }
         
-        try? FileManager.default.removeItem(at: outputURL)
+        // #161: Block if destination already exists
+        if let reason = ExportUtilities.guardDestination(outputURL) {
+            exportMessage = reason
+            showExportError = true
+            return
+        }
         
         do {
             try pdfManager.exportOptimizedPDF(excluding: pathsToRemove, to: outputURL)
@@ -1946,7 +1961,12 @@ struct ThumbnailGridView: View {
             return
         }
         
-        try? FileManager.default.removeItem(at: outputURL)
+        // #161: Block if destination already exists
+        if let reason = ExportUtilities.guardDestination(outputURL) {
+            exportMessage = reason
+            showExportError = true
+            return
+        }
         
         do {
             let count = try pdfManager.exportPagesAsPNGZip(excluding: pathsToRemove, to: outputURL)


### PR DESCRIPTION
- Add ExportUtilities.safeExport: temp file + moveItem (no direct write to dest)
- Add ExportUtilities.guardDestination: block export if dest file already exists
- Remove 4x try? FileManager.removeItem(at: outputURL) — root cause of source deletion
- Wrap all export methods in safeExport: ArchiveManager, FolderManager, PDFManager
- Add Logger.export category

Files: ExportUtilities.swift (new), ThumbnailGridView.swift, ArchiveManager.swift,
       FolderManager.swift, PDFManager.swift
Closes #161