### PR TITLE
fix: R key opens Viewer from focused thumbnail instead of last bookmark

### DIFF
--- a/Erimil/Erimil/ThumbnailGridView.swift
+++ b/Erimil/Erimil/ThumbnailGridView.swift
@@ -1377,8 +1377,7 @@ struct ThumbnailGridView: View {
             
         case .exitToFiler:
             // R: in Grid context, open Viewer Mode (R = "read" = enter viewer)
-            let startIndex = lastViewedIndex ?? currentIndex
-            previewMode = .viewer(index: startIndex)
+            previewMode = .viewer(index: currentIndex)
             
         case .toggleReadingDirection:
             // Ctrl+R: toggle reading direction


### PR DESCRIPTION
Remove lastViewedIndex fallback in exitToFiler handler. R key now matches Ctrl+F behavior, using currentIndex directly.

Closes #185