### PR TITLE
#194: Single click → focus only (remove toggleSelection)

### DIFF
--- a/Erimil/Erimil/ThumbnailGridView.swift
+++ b/Erimil/Erimil/ThumbnailGridView.swift
@@ -574,7 +574,6 @@ struct ThumbnailGridView: View {
                                                 .id(item.index)
                                                 .onTapGesture {
                                                     focusedIndex = item.index
-                                                    toggleSelection(item.entry)
                                                 }
                                                 .onAppear {
                                                     loadThumbnailIfNeeded(for: item.entry)


### PR DESCRIPTION
- Grid thumbnail single click now sets focusedIndex only
- Selection toggle (toggleSelection) removed from tap gesture
- Selection remains available via X key
- Viewer Mode entry via R key (unchanged)
- Mouse-based selection to be restored in #199 (Tab mode switching)