### PR TITLE
fix(#196): Prevent stale spinner timer from firing after source switch

### DIFF
--- a/Erimil/Erimil/ThumbnailGridView.swift
+++ b/Erimil/Erimil/ThumbnailGridView.swift
@@ -915,7 +915,7 @@ struct ThumbnailGridView: View {
         
         // Show spinner only if async load takes >100ms
         let spinnerTimer = DispatchWorkItem {
-            guard isLoadingSource else { return }
+            guard loadID == newLoadID, isLoadingSource else { return }
             showLoadingSpinner = true
         }
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1, execute: spinnerTimer)


### PR DESCRIPTION
spinnerTimer closure now checks loadID == newLoadID in addition to isLoadingSource. Without this, a timer scheduled for the previous source could fire during the next source's load cycle, bypassing the 100ms suppression window.