### PR TITLE
#212: Grid spacing setting — configurable via Settings slider

### DIFF
--- a/Erimil/Erimil/AppSettings.swift
+++ b/Erimil/Erimil/AppSettings.swift
@@ -170,6 +170,7 @@ class AppSettings: ObservableObject {
         static let autoSlideIntervalFast   = "autoSlideIntervalFast"       // #172
         static let autoSlideIntervalTurbo  = "autoSlideIntervalTurbo"      // #172
         static let autoSlideLoops          = "autoSlideLoops"              // #172
+        static let gridSpacing             = "gridSpacing"                 // #212
     }
     
     // MARK: - Published Properties
@@ -317,6 +318,12 @@ class AppSettings: ObservableObject {
     /// Auto-Slide loops at end of source (#172, default: true = display/kiosk use)
     @Published var autoSlideLoops: Bool {
         didSet { defaults.set(autoSlideLoops, forKey: Keys.autoSlideLoops) }
+    }
+    
+    /// Grid spacing between thumbnails in pixels (#212)
+    /// Default: 8, range: 0-24
+    @Published var gridSpacing: CGFloat {
+        didSet { defaults.set(Double(gridSpacing), forKey: Keys.gridSpacing) }
     }
     
     /// Build MetadataCarryOverOptions from current settings
@@ -545,6 +552,9 @@ class AppSettings: ObservableObject {
         let savedTurbo = defaults.double(forKey: Keys.autoSlideIntervalTurbo)
         self.autoSlideIntervalTurbo = savedTurbo > 0 ? savedTurbo : 1.5
         self.autoSlideLoops = defaults.object(forKey: Keys.autoSlideLoops) == nil ? true : defaults.bool(forKey: Keys.autoSlideLoops)
+        
+        // #212: Grid spacing (default 8)
+        self.gridSpacing = defaults.object(forKey: Keys.gridSpacing) != nil ? CGFloat(defaults.double(forKey: Keys.gridSpacing)) : 8
     }
     
     // MARK: - Helper Methods
@@ -581,5 +591,6 @@ class AppSettings: ObservableObject {
         autoSlideIntervalFast   = 0.5            // #172
         autoSlideIntervalTurbo  = 1.5            // #172
         autoSlideLoops          = true           // #172
+        gridSpacing             = 8              // #212
     }
 }

--- a/Erimil/Erimil/SettingsView.swift
+++ b/Erimil/Erimil/SettingsView.swift
@@ -43,6 +43,22 @@ struct SettingsView: View {
                     .font(.caption)
             }
             
+            // MARK: - Grid Spacing (#212)
+            Section {
+                HStack {
+                    Text("間隔:")
+                    Slider(value: $settings.gridSpacing, in: 0...24, step: 2)
+                    Text("\(Int(settings.gridSpacing))px")
+                        .frame(width: 40, alignment: .trailing)
+                        .monospacedDigit()
+                }
+            } header: {
+                Text("グリッド間隔")
+            } footer: {
+                Text("サムネイル間の余白。即座に反映されます。")
+                    .font(.caption)
+            }
+            
             // MARK: - Thumbnail Quality (#207)
             Section {
                 Picker("画質プリセット", selection: Binding(

--- a/Erimil/Erimil/ThumbnailGridView.swift
+++ b/Erimil/Erimil/ThumbnailGridView.swift
@@ -194,7 +194,7 @@ struct ThumbnailGridView: View {
     /// Dynamic columns based on thumbnail size
     private var columns: [GridItem] {
         let size = settings.effectiveThumbnailSize
-        return [GridItem(.adaptive(minimum: size, maximum: size + 30), spacing: 8)]
+        return [GridItem(.adaptive(minimum: size, maximum: size), spacing: settings.gridSpacing)]
     }
     
     /// #52: Last viewed index for this source (for bookmark display)
@@ -556,7 +556,7 @@ struct ThumbnailGridView: View {
                     ZStack {
                         ScrollViewReader { scrollProxy in
                             ScrollView {
-                                LazyVGrid(columns: columns, spacing: 8, pinnedViews: [.sectionHeaders]) {
+                                LazyVGrid(columns: columns, spacing: settings.gridSpacing, pinnedViews: [.sectionHeaders]) {
                                     ForEach(gridSections) { section in
                                         Section {
                                             ForEach(section.items) { item in
@@ -1141,7 +1141,7 @@ struct ThumbnailGridView: View {
     
     private func updateColumnCount(for width: CGFloat) {
         let size = settings.effectiveThumbnailSize
-        let itemWidth = size + 8  // size + spacing
+        let itemWidth = size + settings.gridSpacing  // size + spacing
         let padding: CGFloat = 32  // padding on both sides
         let availableWidth = width - padding
         let count = max(1, Int(availableWidth / itemWidth))


### PR DESCRIPTION
- Add gridSpacing property to AppSettings (0-24px, default 8)
- Add "グリッド間隔" slider section to SettingsView
- ThumbnailGridView: replace hardcoded spacing with settings value
- Fix GridItem maximum slack (size+30 → size) to eliminate size-dependent gap
- Changes reflect immediately without source reload