### PR TITLE
#228 Include TileSheet disk cache in Settings Cache Clear

### DIFF
--- a/Erimil/Erimil/CacheManager.swift
+++ b/Erimil/Erimil/CacheManager.swift
@@ -917,12 +917,14 @@ class CacheManager {
             indexLock.unlock()
             saveIndex()
             
+            // Clear tile sheet disk cache
+            TileSheetCache.shared.clearAll()
+            
             Logger.cache.debug("All cache cleared")
         } catch {
             Logger.cache.error("Failed to clear cache: \(error, privacy: .public)")
         }
     }
-    
     /// Get cache size info
     func getCacheInfo() -> (fileCount: Int, totalSize: Int64) {
         let fm = FileManager.default
@@ -940,6 +942,19 @@ class CacheManager {
             }
         }
         
+        // Include tilesheets directory
+        if let tileEnum = fm.enumerator(
+            at: baseDirectory.appendingPathComponent("tilesheets", isDirectory: true),
+            includingPropertiesForKeys: [.fileSizeKey]
+        ) {
+            while let fileURL = tileEnum.nextObject() as? URL {
+                count += 1
+                if let fileSize = try? fileURL.resourceValues(forKeys: [.fileSizeKey]).fileSize {
+                    size += Int64(fileSize)
+                }
+            }
+        }
+
         return (count, size)
     }
     

--- a/Erimil/Erimil/TileSheetCache.swift
+++ b/Erimil/Erimil/TileSheetCache.swift
@@ -254,6 +254,27 @@ class TileSheetCache {
 
         Logger.cache.info("TileSheet: invalidated for \(archiveURL.lastPathComponent)")
     }
+    
+    /// Remove ALL tile sheets (called from CacheManager.clearAllCache).
+    func clearAll() {
+        // Cancel all pending builds
+        pendingLock.lock()
+        for (_, build) in pendingBuilds {
+            build.buildWorkItem?.cancel()
+        }
+        pendingBuilds.removeAll()
+        pendingLock.unlock()
+
+        // Wait for any in-flight build to finish, then delete
+        buildQueue.sync {
+            let fm = FileManager.default
+            if fm.fileExists(atPath: directory.path) {
+                try? fm.removeItem(at: directory)
+            }
+        }
+        createDirectoryIfNeeded()
+        Logger.cache.info("TileSheet: all tile sheets cleared")
+    }
 
     // MARK: - Build
 


### PR DESCRIPTION
- Add TileSheetCache.clearAll(): cancel pending builds, wait for in-flight builds via buildQueue.sync, delete tilesheets/ directory
- Call TileSheetCache.shared.clearAll() from CacheManager.clearAllCache()
- Include tilesheets/ in getCacheInfo() file count and size total

Close #228 