### PR TITLE
Fix #233: Restore grid scroll position when leaving Reader Mode

### DIFF
--- a/Erimil/Erimil/ThumbnailGridView.swift
+++ b/Erimil/Erimil/ThumbnailGridView.swift
@@ -249,8 +249,14 @@ struct ThumbnailGridView: View {
         .onChange(of: entries) { _, newEntries in
             handleEntriesChange(newEntries)
         }
-        .onChange(of: previewMode) { _, newMode in
+        .onChange(of: previewMode) { oldMode, newMode in
             isInViewerMode = newMode.isViewer
+            // #233: Restore grid scroll position when leaving Reader Mode
+            if oldMode.isViewer && newMode == .none, let index = focusedIndex {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                    collectionUpdater.scrollToItem(at: index, animated: false)
+                }
+            }
         }
         .onAppear {
             SourceSwitchTiming.mark("grid.onAppear")


### PR DESCRIPTION
Reader Mode → Grid Mode transition did not scroll to the last viewed item. The grid showed the beginning of the source with no selection carried over.

Root cause: When previewMode changed from .viewer to .none, the view tree switched from ViewerView back to thumbnailBrowserView. Since focusedIndex didn't change during this transition, onChange(of: focusedIndex) never fired, so scrollToItem was never called.

Fix: Use the Group-level onChange(of: previewMode) — which is always in the view tree — to detect viewer→none transition and trigger scrollToItem for the current focusedIndex.

Changed: ThumbnailGridView.swift (L252)