### PR TITLE
Fix #238: Thread-safe tileSheetInitialized with NSLock, remove duplic…

### DIFF
--- a/Erimil/Erimil/ArchiveManager.swift
+++ b/Erimil/Erimil/ArchiveManager.swift
@@ -19,6 +19,9 @@ class ArchiveManager: ImageSource {
     private let accessQueue = DispatchQueue(label: "com.erimil.archive", qos: .userInitiated)
     
     /// #24: Tile sheet state tracking
+    /// #238: initLock protects tileSheetInitialized/prefetchStarted check-and-set
+    /// across accessQueue (listImageEntries) and non-queue (thumbnail) paths.
+    private let initLock = NSLock()
     private var tileSheetInitialized = false
     private var tileSheetAvailable = false
     
@@ -128,9 +131,16 @@ class ArchiveManager: ImageSource {
             // Also guarantees single-thread execution (eliminates N× redundant loads).
             // Only handles "tile sheet exists on disk" case — if no tile sheet,
             // flags stay unset and thumbnail() fallback triggers prefetchAllThumbnails().
-            if !tileSheetInitialized {
+            // #238: initLock protects check-and-set against thumbnail() on other threads.
+            initLock.lock()
+            let needsInit = !tileSheetInitialized
+            if needsInit {
                 tileSheetInitialized = true
                 prefetchStarted = true
+            }
+            initLock.unlock()
+            
+            if needsInit {
                 let tileCache = TileSheetCache.shared
                 if cachedArchiveHash == nil {
                     cachedArchiveHash = tileCache.archiveHash(for: url)
@@ -164,11 +174,16 @@ class ArchiveManager: ImageSource {
     func thumbnail(for entry: ImageEntry, maxSize: CGFloat = AppSettings.shared.effectiveRetinaThumbnailSize) -> NSImage? {
         // #24: Tile sheet initialization — fallback for when thumbnail() is called
         // before listImageEntries(), or when no tile sheet exists on disk.
-        // Both flags set immediately to prevent other threads from starting prefetch
-        // while this thread loads tile sheet or decides to prefetch.
-        if !tileSheetInitialized {
+        // #238: initLock protects check-and-set against listImageEntries() on accessQueue.
+        initLock.lock()
+        let needsInit = !tileSheetInitialized
+        if needsInit {
             tileSheetInitialized = true
-            prefetchStarted = true  // Block all other threads from prefetch check
+            prefetchStarted = true
+        }
+        initLock.unlock()
+        
+        if needsInit {
             let tileCache = TileSheetCache.shared
             if cachedArchiveHash == nil {
                 cachedArchiveHash = tileCache.archiveHash(for: url)
@@ -312,9 +327,6 @@ class ArchiveManager: ImageSource {
                 )
             }
 
-            Logger.cache.info("TileSheet prefetch: completed \(entries.count, privacy: .public) entries")
-            TileSheetCache.shared.finalizeBuild(for: hash)
-            
             Logger.cache.info("TileSheet prefetch: completed \(entries.count, privacy: .public) entries")
             TileSheetCache.shared.finalizeBuild(for: hash)
             self.tileSheetAvailable = true  // Stop registerThumbnail from on-demand cache hits

--- a/Erimil/Erimil/PDFManager.swift
+++ b/Erimil/Erimil/PDFManager.swift
@@ -32,6 +32,9 @@ class PDFManager: ImageSource {
     // MARK: - Tile Sheet State (#24, S084)
     
     /// Tile sheet init + prefetch flags (consolidated block, S083 race fix pattern)
+    /// #238: initLock protects tileSheetInitialized/prefetchStarted check-and-set
+    /// across accessQueue (listImageEntries) and non-queue (thumbnail) paths.
+    private let initLock = NSLock()
     private var tileSheetInitialized = false
     private var tileSheetAvailable = false
     private var prefetchStarted = false
@@ -85,9 +88,16 @@ class PDFManager: ImageSource {
             // This runs BEFORE any onAppear → loadThumbnailIfNeeded, ensuring the
             // synchronous memory check (SYNC memory hit) in ThumbnailGridView hits
             // for all tile-sheet-covered pages — no loading icon flash.
-            if !tileSheetInitialized {
+            // #238: initLock protects check-and-set against thumbnail() on other threads.
+            initLock.lock()
+            let needsInit = !tileSheetInitialized
+            if needsInit {
                 tileSheetInitialized = true
                 prefetchStarted = true
+            }
+            initLock.unlock()
+            
+            if needsInit {
                 if let hash = pdfHash() {
                     pdfArchiveHash = hash
                     let tileSheet = TileSheetCache.shared
@@ -125,10 +135,16 @@ class PDFManager: ImageSource {
         
         // #24 S084: Fallback init — normally tile sheet is preloaded in listImageEntries().
         // This block fires only if thumbnail() is called before listImageEntries() (edge case).
-        if !tileSheetInitialized {
+        // #238: initLock protects check-and-set against listImageEntries() on accessQueue.
+        initLock.lock()
+        let needsInit = !tileSheetInitialized
+        if needsInit {
             tileSheetInitialized = true
-            prefetchStarted = true  // Set simultaneously to eliminate race window
-            
+            prefetchStarted = true
+        }
+        initLock.unlock()
+        
+        if needsInit {
             if let hash = pdfHash() {
                 pdfArchiveHash = hash
                 let tileSheet = TileSheetCache.shared
@@ -404,9 +420,6 @@ class PDFManager: ImageSource {
                 )
             }
 
-            Logger.pdf.info("TileSheet prefetch: completed \(limit, privacy: .public) pages")
-            tileCache.finalizeBuild(for: hash)
-            
             Logger.pdf.info("TileSheet prefetch: completed \(limit, privacy: .public) pages")
             tileCache.finalizeBuild(for: hash)
             self.tileSheetAvailable = true  // Stop registerThumbnail from on-demand cache hits


### PR DESCRIPTION
…ate finalizeBuild

- Add initLock (NSLock) to protect tileSheetInitialized/prefetchStarted check-and-set across accessQueue (listImageEntries) and non-queue (thumbnail) paths in both ArchiveManager and PDFManager.

- Lock scope is minimal: only the Bool read→write (3 lines). Actual tile sheet loading and prefetch run outside the lock. Post-init calls hit lock→unlock with no contention (~20ns).

- Remove duplicate completed log + finalizeBuild call in prefetchAllThumbnails (copy-paste bug in both files). This caused double TileSheet disk writes per source.

Files modified:
- ArchiveManager.swift (initLock + needsInit pattern ×2, dedup ×1)
- PDFManager.swift (initLock + needsInit pattern ×2, dedup ×1)