### PR TITLE
#255: Add edge-click chevron overlay for Slide/Reader Mode

### DIFF
--- a/Erimil/Erimil/EdgeNavigationOverlay.swift
+++ b/Erimil/Erimil/EdgeNavigationOverlay.swift
@@ -1,0 +1,92 @@
+//
+//  EdgeNavigationOverlay.swift
+//  Erimil
+//
+//  Created for #255 - Edge-click chevron overlay
+//  Session: S114 (2026-04-11)
+//  Shared between Slide Mode and Reader Mode (Viewer Mode)
+//
+
+import SwiftUI
+
+/// #255: Transparent edge-click navigation with hover chevron fade-in.
+/// Click area: left/right halves of the view.
+/// Chevron display: only when hovering within `chevronZoneWidth` of the edge.
+/// Parent must apply `.environment(\.layoutDirection)` for RTL support.
+struct EdgeNavigationOverlay: View {
+    let canGoBack: Bool
+    let canGoForward: Bool
+    let onBack: () -> Void
+    let onForward: () -> Void
+    var chevronZoneWidth: CGFloat = 240
+    
+    @Environment(\.layoutDirection) private var layoutDirection
+    
+    private var isRTL: Bool { layoutDirection == .rightToLeft }
+    
+    @State private var isHoveringBack = false
+    @State private var isHoveringForward = false
+    
+    var body: some View {
+        HStack(spacing: 0) {
+            // Leading half — back
+            Button(action: { if canGoBack { onBack() } }) {
+                Rectangle()
+                    .fill(Color.clear)
+                    .contentShape(Rectangle())
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .overlay(alignment: .leading) {
+                        chevronZone(
+                            systemName: isRTL ? "chevron.right" : "chevron.left",
+                            isHovering: $isHoveringBack,
+                            visible: canGoBack,
+                            iconAlignment: .leading
+                        )
+                    }
+            }
+            .buttonStyle(.plain)
+            
+            // Trailing half — forward
+            Button(action: { if canGoForward { onForward() } }) {
+                Rectangle()
+                    .fill(Color.clear)
+                    .contentShape(Rectangle())
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .overlay(alignment: .trailing) {
+                        chevronZone(
+                            systemName: isRTL ? "chevron.left" : "chevron.right",
+                            isHovering: $isHoveringForward,
+                            visible: canGoForward,
+                            iconAlignment: .trailing
+                        )
+                    }
+            }
+            .buttonStyle(.plain)
+        }
+    }
+    
+    @ViewBuilder
+    private func chevronZone(
+        systemName: String,
+        isHovering: Binding<Bool>,
+        visible: Bool,
+        iconAlignment: Alignment
+    ) -> some View {
+        Rectangle()
+            .fill(Color.clear)
+            .frame(width: chevronZoneWidth)
+            .frame(maxHeight: .infinity)
+            .contentShape(Rectangle())
+            .onHover { isHovering.wrappedValue = $0 }
+            .overlay {
+                Image(systemName: systemName)
+                    .font(.title)
+                    .foregroundStyle(.white)
+                    .shadow(color: .black.opacity(0.8), radius: 4, x: 0, y: 0)
+                    .opacity(visible && isHovering.wrappedValue ? 0.6 : 0)
+                    .animation(.easeInOut(duration: 0.2), value: isHovering.wrappedValue)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: iconAlignment)
+                    .padding(.horizontal, 16)
+            }
+    }
+}

--- a/Erimil/Erimil/SlideWindowController.swift
+++ b/Erimil/Erimil/SlideWindowController.swift
@@ -1656,34 +1656,13 @@ struct SlideWindowView: View {
                 )
                 .environment(\.layoutDirection, effectiveReadingDirection.layoutDirection)  // #150: RTL spread inversion
                 
-                // #245: Edge-click navigation (same UX as Reader Mode)
-                HStack {
-                    if currentIndex > 0 {
-                        Button {
-                            onPrevious?()
-                        } label: {
-                            Rectangle()
-                                .fill(Color.clear)
-                                .frame(width: 60)
-                                .contentShape(Rectangle())
-                        }
-                        .buttonStyle(.plain)
-                    }
-                    
-                    Spacer()
-                    
-                    if currentIndex < entries.count - 1 {
-                        Button {
-                            onNext?()
-                        } label: {
-                            Rectangle()
-                                .fill(Color.clear)
-                                .frame(width: 60)
-                                .contentShape(Rectangle())
-                        }
-                        .buttonStyle(.plain)
-                    }
-                }
+                // #255: Edge-click navigation with chevron overlay
+                EdgeNavigationOverlay(
+                    canGoBack: currentIndex > 0,
+                    canGoForward: currentIndex < entries.count - 1,
+                    onBack: { onPrevious?() },
+                    onForward: { onNext?() }
+                )
                 .environment(\.layoutDirection, effectiveReadingDirection.layoutDirection)  // #245: RTL-aware
             }
             

--- a/Erimil/Erimil/ViewerView.swift
+++ b/Erimil/Erimil/ViewerView.swift
@@ -489,36 +489,13 @@ struct ViewerView: View {
                         }  // #154
                     )
                     
-                    // Navigation hints (left/right edges) - #67: Spread-aware
-                    HStack {
-                        // Left arrow area
-                        if viewerIndex > 0 {
-                            Button {
-                                goToPrevious()
-                            } label: {
-                                Rectangle()
-                                    .fill(Color.clear)
-                                    .frame(width: 60)
-                                    .contentShape(Rectangle())
-                            }
-                            .buttonStyle(.plain)
-                        }
-                        
-                        Spacer()
-                        
-                        // Right arrow area
-                        if viewerIndex < entries.count - 1 {
-                            Button {
-                                goToNext()
-                            } label: {
-                                Rectangle()
-                                    .fill(Color.clear)
-                                    .frame(width: 60)
-                                    .contentShape(Rectangle())
-                            }
-                            .buttonStyle(.plain)
-                        }
-                    }
+                    // #255: Edge-click navigation with chevron overlay
+                    EdgeNavigationOverlay(
+                        canGoBack: viewerIndex > 0,
+                        canGoForward: viewerIndex < entries.count - 1,
+                        onBack: { goToPrevious() },
+                        onForward: { goToNext() }
+                    )
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             }


### PR DESCRIPTION
- New EdgeNavigationOverlay.swift: shared component for both modes
- Click area: left/right halves of view for navigation
- Chevron (SF Symbols) fades in on hover within 240pt edge zone
- RTL-aware: chevron direction flips with layoutDirection
- Shadow for visibility on light backgrounds
- Replaces inline transparent Rectangle buttons in both SlideWindowController.swift and ViewerView.swift