### PR TITLE
Implement Grid Mode N-step source navigation

### DIFF
--- a/Erimil/Erimil/ThumbnailGridView.swift
+++ b/Erimil/Erimil/ThumbnailGridView.swift
@@ -1415,8 +1415,10 @@ struct ThumbnailGridView: View {
             }
         
         case .navigateSourceNStep(let dir):
-            // #257 Phase 2: N-step source navigation in Grid (future enhancement)
-            break
+            // #260: N-step source navigation in Grid Mode
+            let step = AppSettings.shared.navigationStepCount
+            let signedSteps = (dir == .forward) ? step : -step
+            onRequestSourceJump?(signedSteps)
 
             
         default:


### PR DESCRIPTION
Closes #260

Replace the no-op break in .navigateSourceNStep handler with a call to the existing onRequestSourceJump closure (wired from #143).

- Sign convention: .forward → +step, .backward → -step (matches SourceNavigator.jumpSource(from:by:))
- No RTL adjustment: source order is logical (directory listing), not spatial. Existing single-step source nav (Ctrl+W/S) also does not apply RTL inversion.
- Boundary handling delegated to SourceNavigator (nil → no-op).
- shouldReopenViewerMode untouched: Grid Mode stays in Grid Mode after source switch.

Design rationale: see #260 issue comment (posted in S119).

Regression verified:
- W/S alone: Grid column move (unchanged)
- Ctrl+W/S: single-step source switch (unchanged)
- Option+W/S: N-step source navigation (new, this change)
- Option+↑/↓: N-step source navigation (new, same code path)